### PR TITLE
Refactor resource sha256

### DIFF
--- a/karton/core/resource.py
+++ b/karton/core/resource.py
@@ -34,7 +34,7 @@ class ResourceBase(object):
         sha256 = sha256 or metadata.get("sha256")
 
         # flag indicating whether we have to calculate the resource sha256 inside constructor
-        calculate_hash = not bool(sha256) and not _skip_sha256
+        calculate_hash = sha256 is not None and not _skip_sha256
 
         if content and path:
             raise ValueError("Can't set both path and content for resource")
@@ -107,7 +107,7 @@ class ResourceBase(object):
         """
         sha256 = self.metadata.get("sha256")
         if sha256 is None:
-            raise Exception("Resource is missing sha256")
+            raise ValueError("Resource is missing sha256")
         return sha256
 
     def to_dict(self):


### PR DESCRIPTION
The logic behind resource sha256 is currently **very** fuzzy, this PR tries to clean it up by enforcing the following rules:

* All normal (non-directory) resources have to have a `sha256` value in the metadata dictionary. It can be passed either directly as an argument (`sha256`), inside the passed metadata or calculated in the resource constructor.

* Creating a normal (non-directory) resource without specifying the sha256 and passing resource types that can't be directly digested to a hash (like minio parameters) will result in a Exception

* Directory resources, while still basing on the `ResourceBase` class, will be allowed to not have a sha256 value set by setting the constructor `_skip_sha256` flag to True 


Closes #6 