### PR TITLE
Improved Karton logger to not rely on separate Logger instance

### DIFF
--- a/karton/core/base.py
+++ b/karton/core/base.py
@@ -38,7 +38,7 @@ class KartonBase(ABC):
 
     def setup_logger(self, level=None):
         """
-        Sets logger for Karton service (StreamHandler and `karton.logs` handler)
+        Setup logger for Karton service (StreamHandler and `karton.logs` handler)
 
         Called by :py:meth:`Consumer.loop`. If you want to use logger for Producer,
         you need to call it yourself, but remember to set the identity.
@@ -68,6 +68,17 @@ class KartonBase(ABC):
 
     @property
     def log(self):
+        """
+        Return Logger instance for Karton service
+
+        If you want to use it in code that is outside of the Consumer class,
+        use :func:`logging.getLogger`:
+
+        .. code-block:: python
+
+            import logging
+            logging.getLogger("<identity>")
+        """
         return logging.getLogger(self.identity)
 
     def declare_task_state(self, task, status, identity=None):
@@ -86,6 +97,10 @@ class KartonBase(ABC):
 
 
 class KartonServiceBase(KartonBase):
+    def __init__(self, config=None, identity=None):
+        super().__init__(config=config, identity=identity)
+        self.setup_logger()
+
     # Base class for Karton services
     @abc.abstractmethod
     def loop(self):

--- a/karton/core/karton.py
+++ b/karton/core/karton.py
@@ -272,7 +272,6 @@ class Consumer(KartonServiceBase):
         """
         Blocking loop that consumes tasks and runs :py:meth:`karton.Consumer.process` as a handler
         """
-        self.setup_logger()
         self.log.info("Service %s started", self.identity)
 
         # get the old binds and set the new ones atomically
@@ -336,7 +335,6 @@ class LogConsumer(KartonServiceBase):
         raise NotImplementedError()
 
     def loop(self):
-        self.setup_logger()
         self.log.info("Logger %s started", self.identity)
 
         while not self.shutdown:


### PR DESCRIPTION
Currently Karton relies separate `logging.Logger` instance which is not registered in logging module (out of logging hierarchy).

It's hacky and makes it difficult to reuse the logger in other parts of Karton service code. In addition, it's difficult to reuse the handler as well.

What's changed:
- Moved the logger setup to the separate `setup_logger` method. It is called for consumers (at the beginning of `loop` method), but for producers can be called on demand. I don't want to mess up with `logging` each time the Producer is created (it is usually a part of greater app), but I'm not sure if it's a good choice. Any opinions will be appreciated.
- We can refer to the logger both from `self.log` and `logging.getLogger(identity)`.
