### PR TITLE
Fix resource metadata usage

### DIFF
--- a/karton/core/resource.py
+++ b/karton/core/resource.py
@@ -32,7 +32,7 @@ class ResourceBase(object):
         self.bucket = bucket
         self.metadata = metadata or {}
         # the sha256 identifier can be passed as an argument or inside the metadata
-        sha256 = sha256 or metadata.get("sha256")
+        sha256 = sha256 or self.metadata.get("sha256")
 
         calculate_hash = sha256 is None
 


### PR DESCRIPTION
Since metadata could be `None` we should look at `self.metadata`