### PR TITLE
Rework config.py tests

### DIFF
--- a/karton/test.py
+++ b/karton/test.py
@@ -1,20 +1,9 @@
 import os
 import unittest
-from unittest.mock import patch, mock_open
+from unittest.mock import patch, MagicMock, call
 from karton.core import Config, Task
 
-MOCK_CONFIG = """
-[minio]
-access_key = 123
-secret_key = aabbcc
-[redis]
-host = localhost
-port = 1337
-
-[other]
-hello = there
-"""
-
+@patch('configparser.ConfigParser', autospec=True)
 class TestConfig(unittest.TestCase):
     MOCK_ENV = {
         "KARTON_MINIO_ACCESS_KEY": "xd",
@@ -26,50 +15,92 @@ class TestConfig(unittest.TestCase):
         "KARTON_FOO_BAZ": "xxx",
     }
 
-    @patch.dict(os.environ, MOCK_ENV)
-    @patch('builtins.open', mock_open(read_data=MOCK_CONFIG))
-    def test_env_override(self):
-        cfg = Config()
+    def test_missing_sections(self, mock_parser):
+        """ Missing MinIO and Redis sections is an error """
+        parser = mock_parser.return_value
 
-        # Sanity check env values
-        self.assertEqual(cfg["minio"]["access_key"], "xd")
-        self.assertEqual(cfg["minio"]["secure"], "1")
+        def no_section(missing_section):
+            def mock_has_section(sec):
+                return sec != missing_section
+            return mock_has_section
 
-        self.assertEqual(cfg["redis"]["host"], "testhost")
-        self.assertEqual(cfg["redis"]["port"], "2137")
-
-        # Ensure other section not overwritten
-        self.assertEqual(cfg["other"]["hello"], "there")
-
-    @patch.dict(os.environ, MOCK_ENV)
-    def test_only_env_loading(self):
-        cfg = Config()
-        self.assertEqual(cfg["minio"]["access_key"], "xd")
-        self.assertEqual(cfg["minio"]["secure"], "1")
-
-        self.assertEqual(cfg["redis"]["host"], "testhost")
-        self.assertEqual(cfg["redis"]["port"], "2137")
-
-    def test_missing_path(self):
-        with self.assertRaises(IOError):
-            cfg = Config("this_file_doesnt_exist")
-
-    @patch('builtins.open', mock_open(read_data=''))
-    def test_missing_config_section(self):
+        # When no [minio]
+        parser.has_section.side_effect = no_section("minio")
         with self.assertRaises(RuntimeError):
             cfg = Config()
 
-    @patch('builtins.open', mock_open(read_data=MOCK_CONFIG))
-    def test_reading_path_file(self):
-        with patch('os.path.isfile') as mock_isfile:
-            mock_isfile.return_value = True
-            cfg = Config('myconfig')
+        # When no [redis]
+        parser.has_section.side_effect = no_section("redis")
+        with self.assertRaises(RuntimeError):
+            cfg = Config()
+
+        # When no [something] -> no error
+        parser.has_section.side_effect = no_section("something")
+        cfg = Config()
 
     @patch.dict(os.environ, MOCK_ENV)
-    def test_compat_loading(self):
+    def test_env_override(self, mock_parser):
+        """ Test overriding config with variables loaded from environment """
+        parser = mock_parser.return_value
+
+        redis_section = MagicMock()
+        minio_section = MagicMock()
+        foo_section = MagicMock()
+        sections = {
+            "redis": redis_section,
+            "minio": minio_section,
+            "foo": foo_section,
+        }
+
+        def get_section(section):
+            return sections[section]
+        parser.__getitem__.side_effect = get_section
+
+        def has_section(section):
+            return section in ["redis", "minio"]
+        parser.has_section.side_effect = has_section
+
         cfg = Config()
-        self.assertEqual(cfg["minio"], cfg.minio_config)
-        self.assertEqual(cfg["redis"], cfg.redis_config)
+        cfg["redis"]["host"]
+
+        redis_section.__setitem__.assert_has_calls([
+            call("host", "testhost"),
+            call("port", "2137"),
+        ])
+
+        minio_section.__setitem__.assert_has_calls([
+            call("access_key", "xd"),
+            call("secure", "1"),
+        ])
+
+        foo_section.__setitem__.assert_has_calls([
+            call("bar", "aaa"),
+            call("baz", "xxx"),
+        ])
+
+    @patch.dict(os.environ, MOCK_ENV)
+    def test_compat_loading(self, mock_parser):
+        """ Ensure legacy configration access is working """
+        parser = mock_parser.return_value
+        cfg = Config()
+
+        parser.__getitem__.return_value = dict(test="xd")
+
+        self.assertEqual(cfg.minio_config["test"], "xd")
+        self.assertEqual(cfg.redis_config["test"], "xd")
+
+    @patch('os.path.isfile')
+    def test_missing_config_file(self, mock_isfile, mock_parser):
+        """ Test missing config file """
+        mock_isfile.return_value = False
+        with self.assertRaises(IOError):
+            cfg = Config("this_file_doesnt_exist")
+
+    @patch('os.path.isfile')
+    def test_load_from_file(self, mock_isfile, mock_parser):
+        """ Test missing config file """
+        mock_isfile.return_value = True
+        cfg = Config("wew")
 
 
 class TestTask(unittest.TestCase):


### PR DESCRIPTION
Currently implemented tests fail on Python 3.6 which is probably
caused by mock_open.

Rework the tests to have 100% config.py coverage and work correctly on
Python 3.6.