### PR TITLE
Add PEP 561 typing stub

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
     description="Distributed malware analysis orchestration framework",
     namespace_packages=["karton"],
     packages=["karton.core", "karton.system"],
+    package_data={"karton.core": ["py.typed"]},
     install_requires=open("requirements.txt").read().splitlines(),
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
This should allow Karton services to use type hints from karton.core