### PR TITLE
replace docker run with entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ RUN pip install -r requirements.txt
 COPY ./karton ./karton
 COPY ./setup.py ./setup.py
 RUN pip install .
-CMD karton-system
+ENTRYPOINT karton-system


### PR DESCRIPTION
This is a small quality of life change, for people wanting to add arguments to `karton-system` (for example `--setup-bucket`). In a docker-compose it changes from:
```yml
command: ["karton-system", "--setup-bucket"]
```
to:
```yml
command: ["--setup-bucket"]
```