### PR TITLE
remove dev dockerfile completely

### DIFF
--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -18,9 +18,11 @@ services:
   system:
     build:
       context: ..
-      dockerfile: dev/system.Dockerfile
     env_file:
       - karton-vars.env
+    command:
+      - "karton-system"
+      - "--setup-bucket"
     depends_on:
       - minio
       - redis

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -21,7 +21,6 @@ services:
     env_file:
       - karton-vars.env
     command:
-      - "karton-system"
       - "--setup-bucket"
     depends_on:
       - minio

--- a/dev/system.Dockerfile
+++ b/dev/system.Dockerfile
@@ -1,9 +1,0 @@
-FROM python:3.7
-
-COPY requirements.txt /karton/
-COPY setup.py /karton/
-COPY karton/ /karton/karton/
-
-RUN pip install --no-cache-dir /karton
-
-CMD karton-system --setup-bucket


### PR DESCRIPTION
This file is unnecessary (provides no other functionality than main Dockerfile). Moreover, it's just asking to be desynced from main Dockerfile and be a source of frustration and hours of debugging, as it's not used in CI. Could be simplfied more if #84 is merged.