### PR TITLE
add better tags on dockerhub

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,9 +3,6 @@ on:
   push:
     branches:
     - master
-  pull_request:
-    branches:
-    - master
 jobs:
   build_core:
     name: Build image
@@ -22,5 +19,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
           dockerfile: ./Dockerfile
           repository: certpl/karton-system
-          tags: ${{ github.sha }}
+          tags:
+            - ${{ github.sha }}
+            - 'master'
           push: ${{ github.event_name == 'push' }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,4 +22,4 @@ jobs:
           tags:
             - ${{ github.sha }}
             - 'master'
-          push: ${{ github.event_name == 'push' }}
+          push: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     tags: 'v*.*.*'
 
 jobs:
-  release:
+  release_pypi:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -18,3 +18,24 @@ jobs:
       with:
         user: __token__
         password: ${{ secrets.pypi_password }}
+  release_dockerhub:
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_BUILDKIT: 1
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+      - name: Build and push the image
+        uses: docker/build-push-action@v1.1.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          dockerfile: ./Dockerfile
+          repository: certpl/karton-system
+          tags:
+            - ${{ github.sha }}
+            # tag release
+            - ${{ github.event.ref }}
+            # docker's `latest` tag is really `default` and not latest
+            - 'latest'
+          push: ${{ github.event_name == 'push' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release new Karton core version
 
 on:
-  push:
+  create:
     tags: 'v*.*.*'
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,4 +38,4 @@ jobs:
             - ${{ github.event.ref }}
             # docker's `latest` tag is really `default` and not latest
             - 'latest'
-          push: ${{ github.event_name == 'push' }}
+          push: true


### PR DESCRIPTION
This PR:
 - removes push of docker images until they are merged into master
 - pushes all commits from master to dockerhub with sha and uses `master` as a pointer to latest image
 - pushes all tags to dockerhub with sha, tag name and `latest` as a pointer to latest release
 
 The reasoning for `latest` and `master` dockerhub tags is [here](https://blog.container-solutions.com/docker-latest-confusion).
 
 If this works properly, we can add this to all other related projects.