### PR TITLE
CI: Fixed publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
           dockerfile: ./Dockerfile
           repository: certpl/karton-system
-          tags:
-            - ${{ github.sha }}
-            - 'master'
+          tags: |
+            ${{ github.sha }}
+            'master'
           push: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,10 +32,8 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
           dockerfile: ./Dockerfile
           repository: certpl/karton-system
-          tags:
-            - ${{ github.sha }}
-            # tag release
-            - ${{ github.event.ref }}
-            # docker's `latest` tag is really `default` and not latest
-            - 'latest'
+          tags: |
+            ${{ github.sha }}
+            ${{ github.event.ref }}
+            'latest'
           push: true


### PR DESCRIPTION
The type accepted by `docker/build-push-action` was surprising.