### PR TITLE
Refactor cli to use KartonBackend

### DIFF
--- a/karton/core/main.py
+++ b/karton/core/main.py
@@ -2,9 +2,9 @@ import argparse
 from typing import Any, Dict, List
 
 from .__version__ import __version__
+from .backend import KartonBackend
 from .config import Config
 from .karton import Consumer
-from .backend import KartonBackend
 
 
 def print_bind_list(config: Config) -> None:


### PR DESCRIPTION
Cli was created when we didn't have the awesome `KartonBackend`, it allows us to perform the inspection with much less effort and without directly interacting with Redis.

Closes #83 