### PR TITLE
Expose service version in binds

### DIFF
--- a/karton/core/backend.py
+++ b/karton/core/backend.py
@@ -115,7 +115,7 @@ class KartonBackend:
                 version="2.x.x",
                 persistent=not identity.endswith(".test"),
                 filters=bind,
-                service_version="?",
+                service_version=None,
             )
         return KartonBind(
             identity=identity,
@@ -123,7 +123,7 @@ class KartonBackend:
             version=bind["version"],
             persistent=bind["persistent"],
             filters=bind["filters"],
-            service_version=bind.get("service_version", "?"),
+            service_version=bind.get("service_version"),
         )
 
     def get_bind(self, identity: str) -> KartonBind:

--- a/karton/core/backend.py
+++ b/karton/core/backend.py
@@ -18,7 +18,8 @@ KARTON_TASK_NAMESPACE = "karton.task"
 
 
 KartonBind = namedtuple(
-    "KartonBind", ["identity", "info", "version", "persistent", "filters", "service_version"]
+    "KartonBind",
+    ["identity", "info", "version", "persistent", "filters", "service_version"],
 )
 
 

--- a/karton/core/backend.py
+++ b/karton/core/backend.py
@@ -18,7 +18,7 @@ KARTON_TASK_NAMESPACE = "karton.task"
 
 
 KartonBind = namedtuple(
-    "KartonBind", ["identity", "info", "version", "persistent", "filters"]
+    "KartonBind", ["identity", "info", "version", "persistent", "filters", "service_version"]
 )
 
 
@@ -90,6 +90,7 @@ class KartonBackend:
                 "version": bind.version,
                 "filters": bind.filters,
                 "persistent": bind.persistent,
+                "service_version": bind.service_version,
             },
             sort_keys=True,
         )
@@ -113,6 +114,7 @@ class KartonBackend:
                 version="2.x.x",
                 persistent=not identity.endswith(".test"),
                 filters=bind,
+                service_version="?",
             )
         return KartonBind(
             identity=identity,
@@ -120,6 +122,7 @@ class KartonBackend:
             version=bind["version"],
             persistent=bind["persistent"],
             filters=bind["filters"],
+            service_version=bind.get("service_version", "?"),
         )
 
     def get_bind(self, identity: str) -> KartonBind:

--- a/karton/core/karton.py
+++ b/karton/core/karton.py
@@ -216,7 +216,7 @@ class Consumer(KartonServiceBase):
             version=__version__,
             filters=self.filters,
             persistent=self.persistent,
-            service_version=self.__class__.__version__,
+            service_version=self.__class__.version,
         )
 
     def add_pre_hook(

--- a/karton/core/karton.py
+++ b/karton/core/karton.py
@@ -216,6 +216,7 @@ class Consumer(KartonServiceBase):
             version=__version__,
             filters=self.filters,
             persistent=self.persistent,
+            service_version=self.__class__.__version__,
         )
 
     def add_pre_hook(


### PR DESCRIPTION
Some time ago we've added a `version` field for new consumers, this PR exposes them in the bind stored in Redis so we can process these versions in other systems (like dashboard)

Open questions:
 * Should it be named `service_version` or `consumer_version`? (or something else)

Closes #69 