### PR TITLE
CI: Use 'push' event for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release new Karton core version
 
 on:
-  create:
+  push:
     tags: 'v*.*.*'
 
 jobs:
@@ -37,6 +37,6 @@ jobs:
         with:
           tags: |
             certpl/karton-system:${{ github.sha }}
-            certpl/karton-system:${{ github.event.ref }}
+            certpl/karton-system:${{ github.event.release.tag_name }}
             certpl/karton-system:latest
           push: true


### PR DESCRIPTION
https://github.community/t/how-to-get-just-the-tag-name/16241/21

I hope it doesn't require the actual `release` event instead of `push`