### PR TITLE
Add formatter to KartonLogHandler

### DIFF
--- a/karton/core/base.py
+++ b/karton/core/base.py
@@ -54,7 +54,7 @@ class KartonBase(abc.ABC):
         if not self.identity:
             raise ValueError("Can't setup logger without identity")
 
-        self.log_handler.setFormatter(logging.Formatter("%(message)s"))
+        self.log_handler.setFormatter(logging.Formatter())
 
         logger = logging.getLogger(self.identity)
         logger.setLevel(log_level)

--- a/karton/core/base.py
+++ b/karton/core/base.py
@@ -54,6 +54,8 @@ class KartonBase(abc.ABC):
         if not self.identity:
             raise ValueError("Can't setup logger without identity")
 
+        self.log_handler.setFormatter(logging.Formatter("%(message)s"))
+
         logger = logging.getLogger(self.identity)
         logger.setLevel(log_level)
         stream_handler = logging.StreamHandler()

--- a/karton/core/logger.py
+++ b/karton/core/logger.py
@@ -46,6 +46,7 @@ class KartonLogHandler(logging.Handler):
                 log_line["excType"] = exc_type.__name__
 
         log_line["type"] = "log"
+        log_line["message"] = self.format(record)
 
         if self.task is not None:
             log_line["task"] = self.task.serialize()


### PR DESCRIPTION
This change ensures that output of KartonLogHandler doesn't depend on
other formatters setting the "message" field. This would break if the
handler was added to a logger without any other handlers.