### PR TITLE
Fix type typo in LocalResource constructor

### DIFF
--- a/karton/core/resource.py
+++ b/karton/core/resource.py
@@ -180,7 +180,7 @@ class LocalResource(ResourceBase):
     def __init__(
         self,
         name: str,
-        content: Optional[bytes] = None,
+        content: Optional[Union[str, bytes]] = None,
         path: Optional[str] = None,
         bucket: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,


### PR DESCRIPTION
Since `ResourceBase` accepts `Optional[Union[str, bytes]]` I think it makes no sense in limiting ourselves to bytes there