### PR TITLE
Expose karton metrics via the backend API

### DIFF
--- a/karton/core/backend.py
+++ b/karton/core/backend.py
@@ -423,6 +423,11 @@ class KartonBackend:
         self.redis.hincrby(metric.value, identity, 1)
 
     def get_metrics(self, metric: KartonMetrics) -> Dict[str, int]:
+        """
+        Get a {karton-identity: current-number-of-tasks} mapping for a given metric.
+
+        :param metric: Operation metric type
+        """
         return {k: int(v) for k, v in self.redis.hgetall(metric.value).items()}
 
     def upload_object(

--- a/karton/core/backend.py
+++ b/karton/core/backend.py
@@ -422,6 +422,9 @@ class KartonBackend:
         """
         self.redis.hincrby(metric.value, identity, 1)
 
+    def get_metrics(self, metric: KartonMetrics) -> Dict[str, int]:
+        return {k: int(v) for k, v in self.redis.hgetall(metric.value).items()}
+
     def upload_object(
         self,
         bucket: str,


### PR DESCRIPTION
Expose the metrics via the backend API, so we can code https://github.com/CERT-Polska/karton-dashboard/pull/39 more cleanly