### PR TITLE
Feature/redis auth

### DIFF
--- a/karton/core/backend.py
+++ b/karton/core/backend.py
@@ -42,8 +42,12 @@ class KartonBackend:
             secure=bool(int(config["minio"].get("secure", True))),
         )
 
-    def make_redis(self, config):
+    def make_redis(self, config) -> StrictRedis:
         """
+        Create and test a Redis connection.
+
+        :param config: The karton configuration
+        :return: Redis conection
         """
         redis_args = {
             "host": config["redis"]["host"],

--- a/karton/core/backend.py
+++ b/karton/core/backend.py
@@ -5,7 +5,7 @@ from io import BytesIO
 from typing import Any, BinaryIO, Dict, Iterator, List, Optional, Tuple, Union
 
 from minio import Minio
-from redis import StrictRedis, AuthenticationError
+from redis import AuthenticationError, StrictRedis
 from urllib3.response import HTTPResponse
 
 from .task import Task, TaskPriority, TaskState

--- a/karton/core/backend.py
+++ b/karton/core/backend.py
@@ -5,7 +5,7 @@ from io import BytesIO
 from typing import Any, BinaryIO, Dict, Iterator, List, Optional, Tuple, Union
 
 from minio import Minio
-from redis import StrictRedis
+from redis import StrictRedis, AuthenticationError
 from urllib3.response import HTTPResponse
 
 from .task import Task, TaskPriority, TaskState
@@ -34,17 +34,34 @@ class KartonMetrics(enum.Enum):
 class KartonBackend:
     def __init__(self, config):
         self.config = config
-        self.redis = StrictRedis(
-            host=config["redis"]["host"],
-            port=int(config["redis"].get("port", 6379)),
-            decode_responses=True,
-        )
+        self.redis = self.make_redis(config)
         self.minio = Minio(
             endpoint=config["minio"]["address"],
             access_key=config["minio"]["access_key"],
             secret_key=config["minio"]["secret_key"],
             secure=bool(int(config["minio"].get("secure", True))),
         )
+
+    def make_redis(self, config):
+        """
+        """
+        redis_args = {
+            "host": config["redis"]["host"],
+            "port": int(config["redis"].get("port", 6379)),
+            "password": config["redis"].get("password"),
+            "decode_responses": True,
+        }
+        try:
+            redis = StrictRedis(**redis_args)
+            redis.ping()
+        except AuthenticationError:
+            # Maybe we've sent a wrong password.
+            # Or maybe the server is not (yet) password protected
+            # To make smooth transition possible, try to login insecurely
+            del redis_args["password"]
+            redis = StrictRedis(**redis_args)
+            redis.ping()
+        return redis
 
     @property
     def default_bucket_name(self) -> str:

--- a/karton/core/main.py
+++ b/karton/core/main.py
@@ -25,20 +25,25 @@ def configuration_wizard(config_filename: str) -> None:
     config = ConfigParser()
 
     log.info("Configuring MinIO")
+    minio_access_key = "minioadmin"
+    minio_secret_key = "minioadmin"
+    minio_address = "localhost:9000"
+    minio_bucket = "karton"
+    minio_secure = "0"
     while True:
         minio_access_key = get_user_option(
-            "Enter the MinIO access key", default="minioadmin"
+            "Enter the MinIO access key", default=minio_access_key
         )
         minio_secret_key = get_user_option(
-            "Enter the MinIO secret key", default="minioadmin"
+            "Enter the MinIO secret key", default=minio_secret_key
         )
         minio_address = get_user_option(
-            "Enter the MinIO address", default="localhost:9000"
+            "Enter the MinIO address", default=minio_address
         )
         minio_bucket = get_user_option(
-            "Enter the MinIO bucket to use", default="karton"
+            "Enter the MinIO bucket to use", default=minio_bucket
         )
-        minio_secure = get_user_option('Use SSL ("0", "1")?', default="0")
+        minio_secure = get_user_option('Use SSL ("0", "1")?', default=minio_secure)
 
         log.info("Testing MinIO connection...")
         minio = Minio(
@@ -78,19 +83,23 @@ def configuration_wizard(config_filename: str) -> None:
         "secret_key": minio_secret_key,
         "address": minio_address,
         "bucket": minio_bucket,
-        "secure": str(bool(int(minio_secure))),
+        "secure": minio_secure,
     }
 
     log.info("Configuring Redis")
 
+    redis_host = "localhost"
+    redis_port = "6379"
     while True:
-        redis_host = get_user_option("Enter the Redis host", default="localhost")
-        redis_port = get_user_option("Enter the Redis port", default="6379")
+        redis_host = get_user_option("Enter the Redis host", default=redis_host)
+        redis_port = get_user_option("Enter the Redis port", default=redis_port)
+        redis_password = get_user_option("Enter the Redis password (enter to skip)", default="")
 
-        log.info("Testing Redis connection...")
+        log.info("Testing the Redis connection...")
         redis = StrictRedis(
             host=redis_host,
             port=int(redis_port),
+            password=redis_password or None,
             decode_responses=True,
         )
         try:
@@ -114,6 +123,9 @@ def configuration_wizard(config_filename: str) -> None:
         "host": redis_host,
         "port": str(int(redis_port)),
     }
+
+    if redis_password:
+        config["redis"]["password"] = redis_password
 
     with open(config_filename, "w") as configfile:
         config.write(configfile)

--- a/karton/core/main.py
+++ b/karton/core/main.py
@@ -93,7 +93,9 @@ def configuration_wizard(config_filename: str) -> None:
     while True:
         redis_host = get_user_option("Enter the Redis host", default=redis_host)
         redis_port = get_user_option("Enter the Redis port", default=redis_port)
-        redis_password = get_user_option("Enter the Redis password (enter to skip)", default="")
+        redis_password = get_user_option(
+            "Enter the Redis password (enter to skip)", default=""
+        )
 
         log.info("Testing the Redis connection...")
         redis = StrictRedis(


### PR DESCRIPTION
We should support a Redis auth someday (as per ~#108~ #107).

This PR adds this feature.

I've also:
 - modified the `karton configure` commend to ask for redis password
 - fixed a bug in the karton configure...
 - made the `karton configure` a tiny bit more user friendly (it remembers the already entered values)

To make smooth transition possible, having a `password` in a config is not a bug, even when Redis does not require password yet (this will raise AuthenticationException with py-redis library).
