### PR TITLE
retry blocking blpop calls

### DIFF
--- a/karton/core/base.py
+++ b/karton/core/base.py
@@ -111,6 +111,7 @@ class KartonServiceBase(KartonBase):
     def graceful_shutdown(self) -> None:
         self.log.info("Gracefully shutting down!")
         self.shutdown = True
+        self.backend.shutdown = True
 
     # Base class for Karton services
     @abc.abstractmethod


### PR DESCRIPTION
This change set retries calls to be able to survive Redis restarts or
intermitted network connectivity issues.