### PR TITLE
implement status signaling

### DIFF
--- a/karton/core/backend.py
+++ b/karton/core/backend.py
@@ -39,7 +39,7 @@ class KartonBackend:
             endpoint=config["minio"]["address"],
             access_key=config["minio"]["access_key"],
             secret_key=config["minio"]["secret_key"],
-            secure=bool(int(config["minio"].get("secure", True))),
+            secure=config.config.getboolean("minio", "secure", fallback=True),
         )
 
     def make_redis(self, config) -> StrictRedis:

--- a/karton/core/karton.py
+++ b/karton/core/karton.py
@@ -395,31 +395,33 @@ class Karton(Consumer, Producer):
         super(Karton, self).__init__(config=config, identity=identity, backend=backend)
 
         if self.config.config.has_section("signaling"):
-            if bool(int(self.config["signaling"].get("status", 1))):
+            if self.config.config.getboolean("signaling", "status", fallback=False):
                 self.log.info("Using status signaling")
-                self.add_pre_hook(self._send_status_task_begin, "begin")
-                self.add_post_hook(self._send_status_task_end, "end")
+                self.add_pre_hook(self._send_signaling_status_task_begin, "task_begin")
+                self.add_post_hook(self._send_signaling_status_task_end, "task_end")
 
-    def _send_status_task_begin(self, task: Task) -> None:
-        """Send a begin status task.
-
-        :meta private:
-        """
-        self._send_status_task("begin")
-
-    def _send_status_task_end(self, task: Task, ex: Optional[Exception]) -> None:
-        """Send a begin status task.
+    def _send_signaling_status_task_begin(self, task: Task) -> None:
+        """Send a begin status signaling task.
 
         :meta private:
         """
-        self._send_status_task("end")
+        self._send_signaling_status_task("task_begin")
 
-    def _send_status_task(self, status: str) -> None:
-        """Send a status task.
+    def _send_signaling_status_task_end(
+        self, task: Task, ex: Optional[Exception]
+    ) -> None:
+        """Send a begin status signaling task.
+
+        :meta private:
+        """
+        self._send_signaling_status_task("task_end")
+
+    def _send_signaling_status_task(self, status: str) -> None:
+        """Send a status signaling task.
 
         :param status: Status task identifier.
 
         :meta private:
         """
-        task = Task({"type": "status", "status": status})
+        task = Task({"type": "karton.signaling.status", "status": status})
         self.send_task(task)

--- a/karton/core/karton.py
+++ b/karton/core/karton.py
@@ -385,3 +385,41 @@ class Karton(Consumer, Producer):
     """
     This glues together Consumer and Producer - which is the most common use case
     """
+
+    def __init__(
+        self,
+        config: Optional[Config] = None,
+        identity: Optional[str] = None,
+        backend: Optional[KartonBackend] = None,
+    ) -> None:
+        super(Karton, self).__init__(config=config, identity=identity, backend=backend)
+
+        if self.config.config.has_section("signaling"):
+            if bool(int(self.config["signaling"].get("status", 1))):
+                self.log.info("Using status signaling")
+                self.add_pre_hook(self._send_status_task_begin, "begin")
+                self.add_post_hook(self._send_status_task_end, "end")
+
+    def _send_status_task_begin(self, task: Task) -> None:
+        """Send a begin status task.
+
+        :meta private:
+        """
+        self._send_status_task("begin")
+
+    def _send_status_task_end(self, task: Task, ex: Optional[Exception]) -> None:
+        """Send a begin status task.
+
+        :meta private:
+        """
+        self._send_status_task("end")
+
+    def _send_status_task(self, status: str) -> None:
+        """Send a status task.
+
+        :param status: Status task identifier.
+
+        :meta private:
+        """
+        task = Task({"type": "status", "status": status})
+        self.send_task(task)


### PR DESCRIPTION
This change set adds the ability for karton instances to signal to downstream
consumers about the beginning and ending of task execution. Signaling is
performed by sending corresponding "status" tasks.

Task signaling is enabled using the following entry in the karton
configuration file:
```
[signaling]
status = 1
```

Task signaling is disabled by default.