### PR TITLE
doc: Fix syntax errors

### DIFF
--- a/karton/core/resource.py
+++ b/karton/core/resource.py
@@ -160,8 +160,8 @@ class LocalResource(ResourceBase):
     .. code-block:: python
 
         # Creating resource from bytes
-        sample = Resource("original_name.exe", content=b"X5O!P%@AP[4
-        \\PZX54(P^)7CC)7}$EICAR-STANDARD-ANT...")
+        sample = Resource("original_name.exe", content=b"X5O!P%@AP[4\\
+        PZX54(P^)7CC)7}$EICAR-STANDARD-ANT...")
 
         # Creating resource from path
         sample = Resource("original_name.exe", path="sample/original_name.exe")

--- a/karton/core/task.py
+++ b/karton/core/task.py
@@ -39,7 +39,7 @@ class Task(object):
     :param priority: Priority of whole task subtree, \
                      propagated from initial task like `payload_persistent`
     :param parent_uid: Id of a routed task that has created this task by a karton with \
-                       `py:meth:`send_task
+                       :py:meth:`.send_task`
     :param root_uid: Id of a unrouted task that is the root of this tasks analysis tree
     :param orig_uid: Id of a unrouted (or crashed routed) task that was forked to \
                      create this task


### PR DESCRIPTION
Fix following warnings from Sphinx:

docstring of karton.core.task.Task:7: WARNING:
Inline interpreted text or phrase reference start-string without end-string.

docstring of karton.core.resource.LocalResource:6: WARNING:
Could not lex literal_block as "python". Highlighting skipped.