### PR TITLE
WIP: Store producers output in Redis

### DIFF
--- a/karton/system/system.py
+++ b/karton/system/system.py
@@ -1,7 +1,7 @@
 import argparse
 import json
 import time
-from typing import Optional
+from typing import Optional, Dict, Any
 
 from karton.core.__version__ import __version__
 from karton.core.backend import KARTON_TASKS_QUEUE, KartonMetrics
@@ -131,6 +131,8 @@ class SystemService(KartonServiceBase):
         online_consumers = self.backend.get_online_consumers()
 
         self.log.info("[%s] Processing task %s", task.root_uid, task.uid)
+        # store the producer-task relationship in redis for task tracking
+        self.backend.log_identity_output(task.headers.get("origin", "unknown"), task.headers)
 
         for bind in self.backend.get_binds():
             identity = bind.identity


### PR DESCRIPTION
Keeping track of all header types spawned by a given karton producer would allow us to build dynamic graphs of task lifecycles

Closes #139 