### PR TITLE
Fix/routing performance

### DIFF
--- a/karton/core/backend.py
+++ b/karton/core/backend.py
@@ -273,6 +273,8 @@ class KartonBackend:
         :param status: New task status (TaskState)
         :param consumer: Consumer identity
         """
+        if task.status == status:
+            return
         self.redis.rpush(
             KARTON_OPERATIONS_QUEUE,
             json.dumps(


### PR DESCRIPTION
DO NOT MERGE, just creating a PR so ideas from here are not lost.

This is more of a RFC than serious PR. With this changes, my karton can handle ~~ 250 created tasks per seconds (this is multiplied by consumers, so probably like 1000 tasks per second handled by router). Before it was ~50 tasks per second in the same setup, and a bit more with GC fixes

Rough notes (for reference, without contetx not worth much)

Initially 70 tasks/second without the `set_task_status` fix, and 

no batch:
```
[2021-12-29 20:15:19,190][INFO] Handling a batch of 416 operatoins
[2021-12-29 20:15:19,294][INFO] Registering: 0.07985520362854004
[2021-12-29 20:15:19,350][INFO] Logging: 0.05623960494995117
[2021-12-29 20:15:19,352][INFO] Tasks: 13.784908056259155 Ops: 8.421041488647461 XY: 1.63694055904922
```

batch set (mset)
```
[2021-12-29 20:22:16,083][INFO] Handling a batch of 989 operatoins
[2021-12-29 20:22:16,159][INFO] Registering: 0.03281068801879883
[2021-12-29 20:22:16,270][INFO] Logging: 0.11011266708374023
[2021-12-29 20:22:16,273][INFO] Tasks: 14.053676128387451 Ops: 4.637300491333008 XY: 3.030507318626639
```

batch set (mset) + batch log (pipeline)
```
[2021-12-29 20:24:39,721][INFO] Handling a batch of 4 operatoins
[2021-12-29 20:24:39,722][INFO] Registering: 0.0005173683166503906
[2021-12-29 20:24:39,723][INFO] Logging: 0.0003826618194580078
[2021-12-29 20:24:39,724][INFO] Tasks: 14.264014482498169 Ops: 2.9601902961730957 XY: 4.818451251533649
```

Had to change benchmark parameters (started handling 150/s). Now 3x 100 tasks/second.

Before (WIP snapshot):

```
[2021-12-29 21:03:23,799][INFO] Tasks: 33.93181824684143 Ops: 3.9670772552490234 XY: 8.553138935737193
```

After initial fixes:
```
[2021-12-29 21:04:52,994][INFO] Tasks: 27.126226663589478 Ops: 5.3787291049957275 XY: 5.043147148585794
[2021-12-29 21:05:52,524][INFO] Tasks: 27.79704785346985 Ops: 4.725023031234741 XY: 5.882819911719016
```

With route_task and metrics
```
[2021-12-29 21:12:26,517][INFO] Tasks: 21.39035677909851 Ops: 7.335975646972656 XY: 2.9157764734781013
```