### PR TITLE
System routing revisited - prepare to parallelization

### DIFF
--- a/karton/core/karton.py
+++ b/karton/core/karton.py
@@ -158,7 +158,7 @@ class Consumer(KartonServiceBase):
         if not self.current_task.matches_filters(self.filters):
             self.log.info("Task rejected because binds are no longer valid.")
             self.backend.set_task_status(
-                self.current_task, TaskState.FINISHED, consumer=self.identity
+                self.current_task, TaskState.FINISHED
             )
             # Task rejected: end of processing
             return
@@ -168,7 +168,7 @@ class Consumer(KartonServiceBase):
         try:
             self.log.info("Received new task - %s", self.current_task.uid)
             self.backend.set_task_status(
-                self.current_task, TaskState.STARTED, consumer=self.identity
+                self.current_task, TaskState.STARTED
             )
 
             self._run_pre_hooks()
@@ -205,7 +205,7 @@ class Consumer(KartonServiceBase):
                 self.current_task.error = exception_str
 
             self.backend.set_task_status(
-                self.current_task, task_state, consumer=self.identity
+                self.current_task, task_state
             )
 
     @property

--- a/karton/core/karton.py
+++ b/karton/core/karton.py
@@ -157,9 +157,7 @@ class Consumer(KartonServiceBase):
 
         if not self.current_task.matches_filters(self.filters):
             self.log.info("Task rejected because binds are no longer valid.")
-            self.backend.set_task_status(
-                self.current_task, TaskState.FINISHED
-            )
+            self.backend.set_task_status(self.current_task, TaskState.FINISHED)
             # Task rejected: end of processing
             return
 
@@ -167,9 +165,7 @@ class Consumer(KartonServiceBase):
 
         try:
             self.log.info("Received new task - %s", self.current_task.uid)
-            self.backend.set_task_status(
-                self.current_task, TaskState.STARTED
-            )
+            self.backend.set_task_status(self.current_task, TaskState.STARTED)
 
             self._run_pre_hooks()
 
@@ -204,9 +200,7 @@ class Consumer(KartonServiceBase):
                 task_state = TaskState.CRASHED
                 self.current_task.error = exception_str
 
-            self.backend.set_task_status(
-                self.current_task, task_state
-            )
+            self.backend.set_task_status(self.current_task, task_state)
 
     @property
     def _bind(self) -> KartonBind:

--- a/karton/system/system.py
+++ b/karton/system/system.py
@@ -79,9 +79,7 @@ class SystemService(KartonServiceBase):
                     for removed_task in removed_tasks:
                         self.log.info("Unwinding task %s", str(removed_task.uid))
                         # Mark task as finished
-                        self.backend.set_task_status(
-                            removed_task, TaskState.FINISHED
-                        )
+                        self.backend.set_task_status(removed_task, TaskState.FINISHED)
                     self.log.info("Non-persistent: removing bind %s", identity)
                     self.backend.unregister_bind(identity)
 
@@ -175,7 +173,9 @@ class SystemService(KartonServiceBase):
                 routed_task.headers.update({"receiver": identity})
                 self.backend.register_task(routed_task, pipe=pipe)
                 self.backend.produce_routed_task(identity, routed_task, pipe=pipe)
-                self.backend.increment_metrics(KartonMetrics.TASK_ASSIGNED, identity, pipe=pipe)
+                self.backend.increment_metrics(
+                    KartonMetrics.TASK_ASSIGNED, identity, pipe=pipe
+                )
 
         # Directly update the task status to be finished
         self.backend.set_task_status(task, TaskState.FINISHED, pipe=pipe)

--- a/karton/system/system.py
+++ b/karton/system/system.py
@@ -32,10 +32,16 @@ class SystemService(KartonServiceBase):
         self.last_gc_trigger = 0.0
 
     def gc_collect_resources(self) -> None:
+        # Collects unreferenced resources left in object storage
         karton_bucket = self.backend.default_bucket_name
         resources_to_remove = set(self.backend.list_objects(karton_bucket))
+        # Note: it is important to get list of resources before getting list of tasks!
+        # Task is created before resource upload to lock the reference to the resource.
         tasks = self.backend.get_all_tasks()
         for task in tasks:
+            if task.status == TaskState.FINISHED:
+                # If task is finished, its references can be safely ignored
+                continue
             for _, resource in task.iterate_resources():
                 # If resource is referenced by task: remove it from set
                 if (
@@ -43,6 +49,7 @@ class SystemService(KartonServiceBase):
                     and resource.uid in resources_to_remove
                 ):
                     resources_to_remove.remove(resource.uid)
+        # Remove unreferenced resources
         for object_name in list(resources_to_remove):
             try:
                 self.backend.remove_object(karton_bucket, object_name)
@@ -58,12 +65,34 @@ class SystemService(KartonServiceBase):
                     object_name,
                 )
 
+    def gc_collect_abandoned_queues(self):
+        online_consumers = self.backend.get_online_consumers()
+        for bind in self.backend.get_binds():
+            identity = bind.identity
+            if identity not in online_consumers and not bind.persistent:
+                # If offline and not persistent: remove queue
+                for queue in self.backend.get_queue_names(identity):
+                    self.log.info(
+                        "Non-persistent: unwinding tasks from queue %s", queue
+                    )
+                    removed_tasks = self.backend.remove_task_queue(queue)
+                    for removed_task in removed_tasks:
+                        self.log.info("Unwinding task %s", str(removed_task.uid))
+                        # Mark task as finished
+                        self.backend.set_task_status(
+                            removed_task, TaskState.FINISHED
+                        )
+                    self.log.info("Non-persistent: removing bind %s", identity)
+                    self.backend.unregister_bind(identity)
+
     def gc_collect_tasks(self) -> None:
+        # Collects finished tasks
         root_tasks = set()
         running_root_tasks = set()
         tasks = self.backend.get_all_tasks()
         enqueued_task_uids = self.backend.get_task_ids_from_queue(KARTON_TASKS_QUEUE)
         current_time = time.time()
+
         for task in tasks:
             root_tasks.add(task.root_uid)
             will_delete = False
@@ -125,55 +154,38 @@ class SystemService(KartonServiceBase):
     def gc_collect(self) -> None:
         if time.time() > (self.last_gc_trigger + self.GC_INTERVAL):
             try:
+                self.gc_collect_abandoned_queues()
                 self.gc_collect_tasks()
                 self.gc_collect_resources()
             except Exception:
                 self.log.exception("GC: Exception during garbage collection")
             self.last_gc_trigger = time.time()
 
-    def process_task(self, task: Task) -> None:
-        online_consumers = self.backend.get_online_consumers()
-
+    def route_task(self, task: Task) -> None:
+        # Performs routing of task
         self.log.info("[%s] Processing task %s", task.root_uid, task.uid)
 
+        pipe = self.backend.make_pipeline()
         for bind in self.backend.get_binds():
             identity = bind.identity
-            if identity not in online_consumers and not bind.persistent:
-                # If unbound and not persistent
-                for queue in self.backend.get_queue_names(identity):
-                    self.log.info(
-                        "Non-persistent: unwinding tasks from queue %s", queue
-                    )
-                    removed_tasks = self.backend.remove_task_queue(queue)
-                    for removed_task in removed_tasks:
-                        self.log.info("Unwinding task %s", str(removed_task.uid))
-                        # Let the karton.system loop finish this task
-                        self.backend.set_task_status(
-                            removed_task, TaskState.FINISHED, consumer=identity
-                        )
-                self.log.info("Non-persistent: removing bind %s", identity)
-                self.backend.unregister_bind(identity)
-                # Since this bind was deleted we can skip the task bind matching
-                continue
-
             if task.matches_filters(bind.filters):
                 routed_task = task.fork_task()
                 routed_task.status = TaskState.SPAWNED
                 routed_task.last_update = time.time()
                 routed_task.headers.update({"receiver": identity})
-                self.backend.register_task(routed_task)
-                self.backend.produce_routed_task(identity, routed_task)
-                self.backend.set_task_status(
-                    routed_task, TaskState.SPAWNED, consumer=identity
-                )
-                self.backend.increment_metrics(KartonMetrics.TASK_ASSIGNED, identity)
+                self.backend.register_task(routed_task, pipe=pipe)
+                self.backend.produce_routed_task(identity, routed_task, pipe=pipe)
+                self.backend.increment_metrics(KartonMetrics.TASK_ASSIGNED, identity, pipe=pipe)
+
+        # Directly update the task status to be finished
+        self.backend.set_task_status(task, TaskState.FINISHED, pipe=pipe)
+        pipe.execute()
 
     def loop(self) -> None:
         self.log.info("Manager {} started".format(self.identity))
 
         while not self.shutdown:
-            # Order does matter! task dispatching must be before
-            # karton.operations to avoid races Timeout must be shorter than GC_INTERVAL,
+            # Timeout must be shorter than GC_INTERVAL,
             # but not too long allowing graceful shutdown
             data = self.backend.consume_queues(
                 [KARTON_TASKS_QUEUE, KARTON_OPERATIONS_QUEUE], timeout=5
@@ -189,13 +201,12 @@ class SystemService(KartonServiceBase):
                         raise RuntimeError(
                             "Task disappeared while popping, this should never happen"
                         )
-
-                    self.process_task(task)
-                    task.last_update = time.time()
-                    task.status = TaskState.FINISHED
-                    # Directly update the task status to be finished
-                    self.backend.register_task(task)
+                    self.route_task(task)
                 elif queue == KARTON_OPERATIONS_QUEUE:
+                    """
+                    Left for backwards compatibility with Karton <=4.3.0.
+                    Earlier versions delegate task status change to karton.system.
+                    """
                     operation_body = json.loads(body)
                     task = Task.unserialize(operation_body["task"])
                     new_status = TaskState(operation_body["status"])

--- a/karton/system/system.py
+++ b/karton/system/system.py
@@ -39,9 +39,6 @@ class SystemService(KartonServiceBase):
         # Task is created before resource upload to lock the reference to the resource.
         tasks = self.backend.get_all_tasks()
         for task in tasks:
-            if task.status == TaskState.FINISHED:
-                # If task is finished, its references can be safely ignored
-                continue
             for _, resource in task.iterate_resources():
                 # If resource is referenced by task: remove it from set
                 if (


### PR DESCRIPTION
Ok so I will put in my two cents to the routing optimization.

- Currently routing is too heavy because it takes care of non-persistent queue unwinding and setting task statuses
- Task status can be set directly by consumers. It doesn't break anything because exclusive task ownership is gathered at the time of popping task out of the queue 

Let's take a look at current task lifetime:
```
1. [PRODUCER] Declares unrouted task with status DECLARED
   Used rresources are referenced and locked from now
2. [PRODUCER] Uploads resources to Minio
3. [PRODUCER] Adds task to unrouted queue
   Task identifier passed to the queue, which passes the task ownership to ANY ROUTER

4. [ANY ROUTER] Gathers unrouted task from the queue
   The first router that gets the task has the ownership
5. [ONE ROUTER] Performs routing:
    - Looks for consumer binds matching the task headers
    - Declares routed task for given consumer bind with status SPAWNED
    - Adds routed task to the consumer queue, passing the ownership to ANY CONSUMER
6. [ONE ROUTER] Sets unrouted task status to FINISHED
   Unrouted task can be safely wiped out by GC.
   But resource references are still locked by routed tasks, registered earlier.

7. [ANY CONSUMER] Gathers routed task from the queue
   The first consumer that gets the task has the ownership
8. [ONE CONSUMER] Sets task status to STARTED
9. [ONE CONSUMER] During processing of the task, can act as producer, holding current resource references and creating new resources/passing existing resources to the new tasks
10. [ONE CONSUMER] Sets task status to FINISHED
```

It also means that routing looks to be safe to be **parallelized**

What I've done in this PR:
- `set_task_status` changes the status directly in Redis instead of delegating that operation to `karton.system` via operations queue. Even though, operations queue must be still processed to keep compatibility with earlier Karton versions.
- Moved non-persistent queue unwinding to the GC (if we parallelize the routing, it doesn't matter if that operation is serialized with task routing or not)
- Pipelined routing operation (doesn't have to be put in transaction though, let me know if I'm wrong)

Open problems / TODOs:

- Non-persistent queue unwinding can race with consumer being disconnected and connected during GC operation. Consumer can start to process a task before the queue is gone and task is marked finished. GC will also remove bind that shouldn't be removed. I think that we have the same problem in current version, but unwinding happens very often so it's hard to trigger that race.
- I have not checked if we miss some logging due to abandoned operations queue.
- Merging it with optimizations from other PRs (e.g. https://github.com/CERT-Polska/karton/pull/145)