### PR TITLE
Store outputs for 30 days

### DIFF
--- a/karton/core/backend.py
+++ b/karton/core/backend.py
@@ -656,7 +656,7 @@ class KartonBackend:
         """
 
         self.redis.sadd(f"{KARTON_OUTPUTS_NAMESPACE}:{identity}", json.dumps(headers))
-        self.redis.expire(f"{KARTON_OUTPUTS_NAMESPACE}:{identity}", 60 * 60)
+        self.redis.expire(f"{KARTON_OUTPUTS_NAMESPACE}:{identity}", 60 * 60 * 24 * 30)
 
     def get_outputs(self) -> List[KartonOutputs]:
         """


### PR DESCRIPTION
Currently, the outputs are stored for an hour. For most systems, an hour doesn't represent the system.
A day isn't very representative, a week is somewhat representative, and a month is pretty accurate.

The difference in store space between an hour and a day isn't much, so is between a day and a month, But the little diff is still very meaningful. 

context: relations graph