### PR TITLE
Option to set gc parameters in config

### DIFF
--- a/karton/system/system.py
+++ b/karton/system/system.py
@@ -2,6 +2,7 @@ import argparse
 import json
 import time
 from typing import List, Optional
+
 import sympy
 
 from karton.core.__version__ import __version__
@@ -42,13 +43,32 @@ class SystemService(KartonServiceBase):
         self.task_crashed_timeout = self.TASK_CRASHED_TIMEOUT
 
         if config.config.has_section("karton-system"):
-            self.gc_interval = int(sympy.sympify(config["task_timeouts"].get("GC_INTERVAL", self.gc_interval)))
-            self.task_dispatched_timeout = int(sympy.sympify(config["task_timeouts"].get(
-                "TASK_DISPATCHED_TIMEOUT", self.task_dispatched_timeout)))
-            self.task_started_timeout = int(sympy.sympify(config["task_timeouts"].get(
-                "TASK_STARTED_TIMEOUT", self.task_started_timeout)))
-            self.task_crashed_timeout = int(sympy.sympify(config["task_timeouts"].get(
-                "TASK_CRASHED_TIMEOUT", self.task_crashed_timeout)))
+            self.gc_interval = int(
+                sympy.sympify(
+                    config["task_timeouts"].get("GC_INTERVAL", self.gc_interval)
+                )
+            )
+            self.task_dispatched_timeout = int(
+                sympy.sympify(
+                    config["task_timeouts"].get(
+                        "TASK_DISPATCHED_TIMEOUT", self.task_dispatched_timeout
+                    )
+                )
+            )
+            self.task_started_timeout = int(
+                sympy.sympify(
+                    config["task_timeouts"].get(
+                        "TASK_STARTED_TIMEOUT", self.task_started_timeout
+                    )
+                )
+            )
+            self.task_crashed_timeout = int(
+                sympy.sympify(
+                    config["task_timeouts"].get(
+                        "TASK_CRASHED_TIMEOUT", self.task_crashed_timeout
+                    )
+                )
+            )
         super(SystemService, self).__init__(config=config)
         self.last_gc_trigger = time.time()
         self.enable_gc = enable_gc

--- a/karton/system/system.py
+++ b/karton/system/system.py
@@ -2,6 +2,7 @@ import argparse
 import json
 import time
 from typing import List, Optional
+import sympy
 
 from karton.core.__version__ import __version__
 from karton.core.backend import (
@@ -24,6 +25,9 @@ class SystemService(KartonServiceBase):
     version = __version__
 
     GC_INTERVAL = 3 * 60
+    TASK_DISPATCHED_TIMEOUT = 24 * 3600
+    TASK_STARTED_TIMEOUT = 24 * 3600
+    TASK_CRASHED_TIMEOUT = 3 * 24 * 3600
 
     def __init__(
         self,
@@ -32,23 +36,23 @@ class SystemService(KartonServiceBase):
         enable_router: bool = True,
         gc_interval: int = GC_INTERVAL,
     ) -> None:
-        self.TASK_DISPATCHED_TIMEOUT = 24 * 3600
-        self.TASK_STARTED_TIMEOUT = 24 * 3600
-        self.TASK_CRASHED_TIMEOUT = 3 * 24 * 3600
+        self.gc_interval = gc_interval
+        self.task_dispatched_timeout = self.TASK_DISPATCHED_TIMEOUT
+        self.task_started_timeout = self.TASK_STARTED_TIMEOUT
+        self.task_crashed_timeout = self.TASK_CRASHED_TIMEOUT
 
         if config.config.has_section("karton-system"):
-            self.GC_INTERVAL = config["task_timeouts"].get("GC_INTERVAL", self.GC_INTERVAL)
-            self.TASK_DISPATCHED_TIMEOUT = config["task_timeouts"].get("TASK_DISPATCHED_TIMEOUT",
-                                                                            self.TASK_DISPATCHED_TIMEOUT)
-            self.TASK_STARTED_TIMEOUT = config["task_timeouts"].get("TASK_STARTED_TIMEOUT",
-                                                                         self.TASK_STARTED_TIMEOUT)
-            self.TASK_CRASHED_TIMEOUT = config["task_timeouts"].get("TASK_CRASHED_TIMEOUT",
-                                                                         self.TASK_CRASHED_TIMEOUT)
+            self.gc_interval = int(sympy.sympify(config["task_timeouts"].get("GC_INTERVAL", self.gc_interval)))
+            self.task_dispatched_timeout = int(sympy.sympify(config["task_timeouts"].get(
+                "TASK_DISPATCHED_TIMEOUT", self.task_dispatched_timeout)))
+            self.task_started_timeout = int(sympy.sympify(config["task_timeouts"].get(
+                "TASK_STARTED_TIMEOUT", self.task_started_timeout)))
+            self.task_crashed_timeout = int(sympy.sympify(config["task_timeouts"].get(
+                "TASK_CRASHED_TIMEOUT", self.task_crashed_timeout)))
         super(SystemService, self).__init__(config=config)
         self.last_gc_trigger = time.time()
         self.enable_gc = enable_gc
         self.enable_router = enable_router
-        self.gc_interval = gc_interval
 
     def gc_collect_resources(self) -> None:
         # Collects unreferenced resources left in object storage
@@ -106,27 +110,27 @@ class SystemService(KartonServiceBase):
                 task.status == TaskState.DECLARED
                 and task.uid not in enqueued_task_uids
                 and task.last_update is not None
-                and current_time > task.last_update + self.TASK_DISPATCHED_TIMEOUT
+                and current_time > task.last_update + self.task_dispatched_timeout
             ):
                 to_delete.append(task)
                 self.log.warning(
                     "Task %s is in Dispatched state more than %d seconds. "
                     "Killed. (origin: %s)",
                     task.uid,
-                    self.TASK_DISPATCHED_TIMEOUT,
+                    self.task_dispatched_timeout,
                     task.headers.get("origin", "<unknown>"),
                 )
             elif (
                 task.status == TaskState.STARTED
                 and task.last_update is not None
-                and current_time > task.last_update + self.TASK_STARTED_TIMEOUT
+                and current_time > task.last_update + self.task_started_timeout
             ):
                 to_delete.append(task)
                 self.log.warning(
                     "Task %s is in Started state more than %d seconds. "
                     "Killed. (receiver: %s)",
                     task.uid,
-                    self.TASK_STARTED_TIMEOUT,
+                    self.task_started_timeout,
                     task.headers.get("receiver", "<unknown>"),
                 )
             elif task.status == TaskState.FINISHED:
@@ -135,14 +139,14 @@ class SystemService(KartonServiceBase):
             elif (
                 task.status == TaskState.CRASHED
                 and task.last_update is not None
-                and current_time > task.last_update + self.TASK_CRASHED_TIMEOUT
+                and current_time > task.last_update + self.task_crashed_timeout
             ):
                 to_delete.append(task)
                 self.log.debug(
                     "GC: Task %s is in Crashed state more than %d seconds. "
                     "Killed. (receiver: %s)",
                     task.uid,
-                    self.TASK_CRASHED_TIMEOUT,
+                    self.task_crashed_timeout,
                     task.headers.get("receiver", "<unknown>"),
                 )
             else:

--- a/karton/system/system.py
+++ b/karton/system/system.py
@@ -35,31 +35,31 @@ class SystemService(KartonServiceBase):
         enable_router: bool = True,
         gc_interval: int = GC_INTERVAL,
     ) -> None:
+        super(SystemService, self).__init__(config=config)
         self.gc_interval = gc_interval
         self.task_dispatched_timeout = self.TASK_DISPATCHED_TIMEOUT
         self.task_started_timeout = self.TASK_STARTED_TIMEOUT
         self.task_crashed_timeout = self.TASK_CRASHED_TIMEOUT
 
-        if config.config.has_section("karton-system"):
+        if self.config.config.has_section("karton-system"):
             self.gc_interval = int(
-                config["task_timeouts"].get("GC_INTERVAL", self.gc_interval)
+                self.config["task_timeouts"].get("GC_INTERVAL", self.gc_interval)
             )
             self.task_dispatched_timeout = int(
-                config["task_timeouts"].get(
+                self.config["task_timeouts"].get(
                     "TASK_DISPATCHED_TIMEOUT", self.task_dispatched_timeout
                 )
             )
             self.task_started_timeout = int(
-                config["task_timeouts"].get(
+                self.config["task_timeouts"].get(
                     "TASK_STARTED_TIMEOUT", self.task_started_timeout
                 )
             )
             self.task_crashed_timeout = int(
-                config["task_timeouts"].get(
+                self.config["task_timeouts"].get(
                     "TASK_CRASHED_TIMEOUT", self.task_crashed_timeout
                 )
             )
-        super(SystemService, self).__init__(config=config)
         self.last_gc_trigger = time.time()
         self.enable_gc = enable_gc
         self.enable_router = enable_router

--- a/karton/system/system.py
+++ b/karton/system/system.py
@@ -24,9 +24,6 @@ class SystemService(KartonServiceBase):
     version = __version__
 
     GC_INTERVAL = 3 * 60
-    TASK_DISPATCHED_TIMEOUT = 24 * 3600
-    TASK_STARTED_TIMEOUT = 24 * 3600
-    TASK_CRASHED_TIMEOUT = 3 * 24 * 3600
 
     def __init__(
         self,
@@ -35,6 +32,18 @@ class SystemService(KartonServiceBase):
         enable_router: bool = True,
         gc_interval: int = GC_INTERVAL,
     ) -> None:
+        self.TASK_DISPATCHED_TIMEOUT = 24 * 3600
+        self.TASK_STARTED_TIMEOUT = 24 * 3600
+        self.TASK_CRASHED_TIMEOUT = 3 * 24 * 3600
+
+        if config.config.has_section("task_timeouts"):
+            self.GC_INTERVAL = config["task_timeouts"].get("GC_INTERVAL", self.GC_INTERVAL)
+            self.TASK_DISPATCHED_TIMEOUT = config["task_timeouts"].get("TASK_DISPATCHED_TIMEOUT",
+                                                                            self.TASK_DISPATCHED_TIMEOUT)
+            self.TASK_STARTED_TIMEOUT = config["task_timeouts"].get("TASK_STARTED_TIMEOUT",
+                                                                         self.TASK_STARTED_TIMEOUT)
+            self.TASK_CRASHED_TIMEOUT = config["task_timeouts"].get("TASK_CRASHED_TIMEOUT",
+                                                                         self.TASK_CRASHED_TIMEOUT)
         super(SystemService, self).__init__(config=config)
         self.last_gc_trigger = time.time()
         self.enable_gc = enable_gc

--- a/karton/system/system.py
+++ b/karton/system/system.py
@@ -36,7 +36,7 @@ class SystemService(KartonServiceBase):
         self.TASK_STARTED_TIMEOUT = 24 * 3600
         self.TASK_CRASHED_TIMEOUT = 3 * 24 * 3600
 
-        if config.config.has_section("task_timeouts"):
+        if config.config.has_section("karton-system"):
             self.GC_INTERVAL = config["task_timeouts"].get("GC_INTERVAL", self.GC_INTERVAL)
             self.TASK_DISPATCHED_TIMEOUT = config["task_timeouts"].get("TASK_DISPATCHED_TIMEOUT",
                                                                             self.TASK_DISPATCHED_TIMEOUT)

--- a/karton/system/system.py
+++ b/karton/system/system.py
@@ -3,8 +3,6 @@ import json
 import time
 from typing import List, Optional
 
-import sympy
-
 from karton.core.__version__ import __version__
 from karton.core.backend import (
     KARTON_OPERATIONS_QUEUE,
@@ -44,29 +42,21 @@ class SystemService(KartonServiceBase):
 
         if config.config.has_section("karton-system"):
             self.gc_interval = int(
-                sympy.sympify(
-                    config["task_timeouts"].get("GC_INTERVAL", self.gc_interval)
-                )
+                config["task_timeouts"].get("GC_INTERVAL", self.gc_interval)
             )
             self.task_dispatched_timeout = int(
-                sympy.sympify(
-                    config["task_timeouts"].get(
-                        "TASK_DISPATCHED_TIMEOUT", self.task_dispatched_timeout
-                    )
+                config["task_timeouts"].get(
+                    "TASK_DISPATCHED_TIMEOUT", self.task_dispatched_timeout
                 )
             )
             self.task_started_timeout = int(
-                sympy.sympify(
-                    config["task_timeouts"].get(
-                        "TASK_STARTED_TIMEOUT", self.task_started_timeout
-                    )
+                config["task_timeouts"].get(
+                    "TASK_STARTED_TIMEOUT", self.task_started_timeout
                 )
             )
             self.task_crashed_timeout = int(
-                sympy.sympify(
-                    config["task_timeouts"].get(
-                        "TASK_CRASHED_TIMEOUT", self.task_crashed_timeout
-                    )
+                config["task_timeouts"].get(
+                    "TASK_CRASHED_TIMEOUT", self.task_crashed_timeout
                 )
             )
         super(SystemService, self).__init__(config=config)


### PR DESCRIPTION
Issue: https://github.com/CERT-Polska/karton/issues/147

Config example:

```toml
[minio]
secret_key = minioadmin
access_key = minioadmin
address = localhost:9000
bucket = karton
secure = 0

[redis]
host=localhost
port=6379

[mongo]
host=localhost
port=27017


[task_timeouts]
GC_INTERVAL = 60
TASK_STARTED_TIMEOUT =2592000
TASK_CRASHED_TIMEOUT = 2592000
```