### PR TITLE
resource.py: metadata["sha256"] is not deprecated

### DIFF
--- a/karton/core/resource.py
+++ b/karton/core/resource.py
@@ -88,7 +88,7 @@ class ResourceBase(object):
                 sha256 = hashlib.sha256(self._content).hexdigest()
 
         # Empty Resource is possible here (e.g. RemoteResource)
-        self.metadata["sha256"] = sha256  # DEPRECATED
+        self.metadata["sha256"] = sha256
 
         self._uid = _uid or str(uuid.uuid4())
         self._path = path


### PR DESCRIPTION
It's a comment that was left after my failure to make a more generic abstraction on resource metadata. Let's just forget about it