### PR TITLE
Fix: Redis client name is lost after reconnection

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,6 @@ jobs:
       - uses: CERT-Polska/lint-python-action@v1
         with:
           source: karton/
-          extra-requirements: "types-redis"
   unittest:
     runs-on: ubuntu-latest
     strategy:

--- a/karton/core/backend.py
+++ b/karton/core/backend.py
@@ -52,7 +52,7 @@ class KartonBackend:
             secure=config.config.getboolean("minio", "secure", fallback=True),
         )
 
-    def make_redis(self, config, identity=None) -> StrictRedis:
+    def make_redis(self, config, identity: Optional[str] = None) -> StrictRedis:
         """
         Create and test a Redis connection.
 

--- a/karton/core/backend.py
+++ b/karton/core/backend.py
@@ -41,7 +41,7 @@ class KartonMetrics(enum.Enum):
 
 
 class KartonBackend:
-    def __init__(self, config, identity=None):
+    def __init__(self, config, identity: Optional[str] = None) -> None:
         self.config = config
         self.identity = identity
         self.redis = self.make_redis(config, identity=identity)

--- a/karton/core/backend.py
+++ b/karton/core/backend.py
@@ -1,6 +1,7 @@
 import enum
 import json
 import time
+import warnings
 from collections import defaultdict, namedtuple
 from io import BytesIO
 from typing import Any, BinaryIO, Dict, Iterator, List, Optional, Set, Tuple, Union
@@ -40,9 +41,10 @@ class KartonMetrics(enum.Enum):
 
 
 class KartonBackend:
-    def __init__(self, config):
+    def __init__(self, config, identity=None):
         self.config = config
-        self.redis = self.make_redis(config)
+        self.identity = identity
+        self.redis = self.make_redis(config, identity=identity)
         self.minio = Minio(
             endpoint=config["minio"]["address"],
             access_key=config["minio"]["access_key"],
@@ -50,17 +52,19 @@ class KartonBackend:
             secure=config.config.getboolean("minio", "secure", fallback=True),
         )
 
-    def make_redis(self, config) -> StrictRedis:
+    def make_redis(self, config, identity=None) -> StrictRedis:
         """
         Create and test a Redis connection.
 
         :param config: The karton configuration
-        :return: Redis conection
+        :param identity: Karton service identity
+        :return: Redis connection
         """
         redis_args = {
             "host": config["redis"]["host"],
             "port": int(config["redis"].get("port", 6379)),
             "password": config["redis"].get("password"),
+            "client_name": identity,
             "decode_responses": True,
         }
         try:
@@ -213,11 +217,15 @@ class KartonBackend:
         """
         self.redis.hdel(KARTON_BINDS_HSET, identity)
 
-    def set_consumer_identity(self, identity: str) -> None:
+    def set_consumer_identity(self, _: str) -> None:
         """
         Sets identity for current Redis connection
         """
-        return self.redis.client_setname(identity)
+        warnings.warn(
+            "set_consumer_identity is deprecated and does nothing from v4.5.0. "
+            "Use identity constructor argument instead",
+            DeprecationWarning,
+        )
 
     def get_online_consumers(self) -> Dict[str, List[str]]:
         """

--- a/karton/core/base.py
+++ b/karton/core/base.py
@@ -25,7 +25,7 @@ class KartonBase(abc.ABC):
             self.identity = identity
 
         self.config = config or Config()
-        self.backend = backend or KartonBackend(self.config)
+        self.backend = backend or KartonBackend(self.config, identity=self.identity)
 
         self.log_handler = KartonLogHandler(backend=self.backend, channel=self.identity)
         self.current_task: Optional[Task] = None

--- a/karton/core/karton.py
+++ b/karton/core/karton.py
@@ -293,8 +293,6 @@ class Consumer(KartonServiceBase):
         for task_filter in self.filters:
             self.log.info("Binding on: %s", task_filter)
 
-        self.backend.set_consumer_identity(self.identity)
-
         try:
             while not self.shutdown:
                 if self.backend.get_bind(self.identity) != self._bind:


### PR DESCRIPTION
Identity is set via constructor, so it should be passed to KartonBackend and set as `client_name` argument in StrictRedis object.

Closes #169 