### PR TITLE
Correctly handle SIGINT/SIGTERM for graceful exit

### DIFF
--- a/karton/core/base.py
+++ b/karton/core/base.py
@@ -9,7 +9,7 @@ from .backend import KartonBackend
 from .config import Config
 from .logger import KartonLogHandler
 from .task import Task
-from .utils import graceful_killer, HardShutdownInterrupt, StrictClassMethod
+from .utils import HardShutdownInterrupt, StrictClassMethod, graceful_killer
 
 
 class KartonBase(abc.ABC):

--- a/karton/core/base.py
+++ b/karton/core/base.py
@@ -2,13 +2,14 @@ import abc
 import argparse
 import logging
 import textwrap
+from contextlib import contextmanager
 from typing import Optional, Union, cast
 
 from .backend import KartonBackend
 from .config import Config
 from .logger import KartonLogHandler
 from .task import Task
-from .utils import GracefulKiller
+from .utils import HardShutdownInterrupt, graceful_killer
 
 
 class KartonBase(abc.ABC):
@@ -191,12 +192,24 @@ class KartonServiceBase(KartonBase):
     ) -> None:
         super().__init__(config=config, identity=identity, backend=backend)
         self.setup_logger()
-        self.shutdown = False
-        self.killer = GracefulKiller(self.graceful_shutdown)
+        self._shutdown = False
 
-    def graceful_shutdown(self) -> None:
-        self.log.info("Gracefully shutting down!")
-        self.shutdown = True
+    def _do_shutdown(self) -> None:
+        self.log.info("Got signal, shutting down...")
+        self._shutdown = True
+
+    @property
+    def shutdown(self):
+        return self._shutdown
+
+    @contextmanager
+    def graceful_killer(self):
+        try:
+            with graceful_killer(self._do_shutdown):
+                yield
+        except HardShutdownInterrupt:
+            self.log.info("Hard shutting down!")
+            raise
 
     # Base class for Karton services
     @abc.abstractmethod

--- a/karton/core/main.py
+++ b/karton/core/main.py
@@ -176,7 +176,7 @@ def delete_bind(config: Config, karton_name: str) -> None:
             pass
 
     karton = KartonDummy(config=config, identity=karton_name)
-    karton.shutdown = True
+    karton._shutdown = True
     karton.loop()
 
 

--- a/karton/core/utils.py
+++ b/karton/core/utils.py
@@ -1,5 +1,6 @@
 import inspect
 import signal
+from contextlib import contextmanager
 from typing import Any, Callable, Iterator, Sequence, TypeVar
 
 T = TypeVar("T")
@@ -13,15 +14,28 @@ def chunks(seq: Sequence[T], size: int) -> Iterator[Sequence[T]]:
     return (seq[pos : pos + size] for pos in range(0, len(seq), size))
 
 
-class GracefulKiller:
-    def __init__(self, handle_func: Callable) -> None:
-        self.handle_func = handle_func
-        self.original_sigint_handler = signal.signal(
-            signal.SIGINT, self.exit_gracefully
-        )
-        signal.signal(signal.SIGTERM, self.exit_gracefully)
+class HardShutdownInterrupt(BaseException):
+    pass
 
-    def exit_gracefully(self, signum: int, frame: Any) -> None:
-        self.handle_func()
-        if signum == signal.SIGINT:
-            signal.signal(signal.SIGINT, self.original_sigint_handler)
+
+@contextmanager
+def graceful_killer(handler: Callable[[], None]):
+    """
+    Graceful killer for Karton consumers.
+    """
+    first_try = True
+
+    def signal_handler(signum: int, frame: Any) -> None:
+        nonlocal first_try
+        handler()
+        if not first_try:
+            raise HardShutdownInterrupt()
+        first_try = False
+
+    original_sigint_handler = signal.signal(signal.SIGINT, signal_handler)
+    original_sigterm_handler = signal.signal(signal.SIGTERM, signal_handler)
+    try:
+        yield
+    finally:
+        signal.signal(signal.SIGINT, original_sigint_handler)
+        signal.signal(signal.SIGTERM, original_sigterm_handler)

--- a/karton/core/utils.py
+++ b/karton/core/utils.py
@@ -36,9 +36,12 @@ def graceful_killer(handler: Callable[[], None]):
     def signal_handler(signum: int, frame: Any) -> None:
         nonlocal first_try
         handler()
-        if not first_try:
-            raise HardShutdownInterrupt()
-        first_try = False
+        if signum == signal.SIGINT:
+            # Sometimes SIGTERM can be prematurely repeated.
+            # Forced but still clean shutdown is implemented only for SIGINT.
+            if not first_try:
+                raise HardShutdownInterrupt()
+            first_try = False
 
     original_sigint_handler = signal.signal(signal.SIGINT, signal_handler)
     original_sigterm_handler = signal.signal(signal.SIGTERM, signal_handler)

--- a/karton/system/system.py
+++ b/karton/system/system.py
@@ -250,15 +250,16 @@ class SystemService(KartonServiceBase):
     def loop(self) -> None:
         self.log.info("Manager %s started", self.identity)
 
-        while not self.shutdown:
-            if self.enable_router:
-                # This will wait for up to 5s, so this is not a busy loop
-                self.process_routing()
-            if self.enable_gc:
-                # This will only do anything once every self.gc_interval seconds
-                self.gc_collect()
-                if not self.enable_router:
-                    time.sleep(1)  # Avoid a busy loop
+        with self.graceful_killer():
+            while not self.shutdown:
+                if self.enable_router:
+                    # This will wait for up to 5s, so this is not a busy loop
+                    self.process_routing()
+                if self.enable_gc:
+                    # This will only do anything once every self.gc_interval seconds
+                    self.gc_collect()
+                    if not self.enable_router:
+                        time.sleep(1)  # Avoid a busy loop
 
     @classmethod
     def args_parser(cls) -> argparse.ArgumentParser:


### PR DESCRIPTION
Signal handlers should not be set inside the constructor of Karton class, because in case of incorrect invocation:

```
KartonClass().main()
```

KartonClass instance is set twice and `GracefulKiller` doesn't correctly fallback to default handler. I replaced it with context manager and raising own exception (`HardShutdownInterrupt`) in case of second try.

~~In previous implementation, second try handler was spawned only when second SIGINT arrived. Should we do the same for SIGTERM?~~ After short research I think hard shutdown should be implemented only for SIGINT.
