### PR TITLE
Redis: Set default socket_timeout and support db/username keys

### DIFF
--- a/karton/core/backend.py
+++ b/karton/core/backend.py
@@ -63,8 +63,12 @@ class KartonBackend:
         redis_args = {
             "host": config["redis"]["host"],
             "port": config.getint("redis", "port", 6379),
+            "db": config.getint("redis", "db", 0),
+            "username": config.get("redis", "username"),
             "password": config.get("redis", "password"),
             "client_name": identity,
+            # set socket_timeout to None if set to 0
+            "socket_timeout": config.getint("redis", "socket_timeout", 30) or None,
             "decode_responses": True,
         }
         try:


### PR DESCRIPTION
By default it seems to come without any timeout.

When I pretend to be a silent server (e.g. proxy with incorrect handling of dropped connection on the other side), it waits forever for an answer. When socket_timeout is set, after 30 seconds it raises `redis.exceptions.TimeoutError: Timeout reading from socket`.

```
$ nc -l 9999
*3
$6
CLIENT
$7
SETNAME
$18
karton.wait-for-it
```

Closes #136 