### PR TITLE
Fix handling on LocalResource with file descriptor as a source

### DIFF
--- a/karton/core/backend.py
+++ b/karton/core/backend.py
@@ -4,7 +4,7 @@ import time
 import warnings
 from collections import defaultdict, namedtuple
 from io import BytesIO
-from typing import Any, BinaryIO, Dict, Iterator, List, Optional, Set, Tuple, Union
+from typing import IO, Any, Dict, Iterator, List, Optional, Set, Tuple, Union
 
 from minio import Minio
 from minio.deleteobjects import DeleteError, DeleteObject
@@ -562,7 +562,7 @@ class KartonBackend:
         self,
         bucket: str,
         object_uid: str,
-        content: Union[bytes, BinaryIO],
+        content: Union[bytes, IO[bytes]],
         length: int = None,
     ) -> None:
         """
@@ -576,6 +576,8 @@ class KartonBackend:
         if isinstance(content, bytes):
             length = len(content)
             content = BytesIO(content)
+        elif length is None:
+            raise ValueError("Length can't be None when file-like object is provided")
         self.minio.put_object(bucket, object_uid, content, length)
 
     def upload_object_from_file(self, bucket: str, object_uid: str, path: str) -> None:

--- a/karton/core/resource.py
+++ b/karton/core/resource.py
@@ -180,7 +180,7 @@ class LocalResource(ResourceBase):
         _flags: Optional[List[str]] = None,
         _close_fd: bool = False,
     ) -> None:
-        if len(list(filter(lambda v: v is not None, [path, content, fd]))) != 1:
+        if len(list(filter(None, [path, content, fd]))) != 1:
             raise ValueError("You must exclusively provide a path, content or fd")
 
         super(LocalResource, self).__init__(


### PR DESCRIPTION
- `fd` is expected as one of LocalResource content sources (closes #29)
- `LocalResource.from_directory` is using TemporaryFile instead of NamedTemporaryFile and access by path
- Typing: mypy says that `IO[bytes]` is incompatible with `BinaryIO` and it looks like the first form is preferred. 
   Quite unexpected by just reading the documentation (https://docs.python.org/3/library/typing.html#typing.BinaryIO) but there are some extra methods added (https://github.com/python/typeshed/blob/master/stdlib/typing.pyi#L700).
   