### PR TITLE
SystemService and backend improvements

### DIFF
--- a/karton/core/backend.py
+++ b/karton/core/backend.py
@@ -286,7 +286,7 @@ class KartonBackend:
         tasks = self.redis.keys(f"{KARTON_TASK_NAMESPACE}:*")
 
         for chunk in chunks(tasks, chunk_size):
-            yield list(map(Task.unserialize, filter(None, self.redis.mget(chunk))))
+            yield map(Task.unserialize, filter(None, self.redis.mget(chunk)))
 
     def register_task(self, task: Task, pipe: Optional[Pipeline] = None) -> None:
         """

--- a/karton/system/system.py
+++ b/karton/system/system.py
@@ -145,9 +145,9 @@ class SystemService(KartonServiceBase):
                     running_root_tasks.add(task.root_uid)
 
             if to_delete:
-                to_increment = Counter([
-                    task.headers.get("receiver", "unknown") for task in to_delete
-                ])
+                to_increment = Counter(
+                    [task.headers.get("receiver", "unknown") for task in to_delete]
+                )
                 self.backend.delete_tasks(to_delete)
                 self.backend.increment_metrics_list(
                     KartonMetrics.TASK_GARBAGE_COLLECTED, to_increment


### PR DESCRIPTION
1. gc collect is safer, avoid loading all the redis tasks into memory
2. optimization of metrics adjustment

The only place which stays unsafe is `@ backend.py get_all_tasks`:
```
tasks = self.redis.keys(f"{KARTON_TASK_NAMESPACE}:*")
```
At this place all the redis tasks keys are loaded into memory, which could lead to MemoryError/redis connection drop in case there are not enough RAM on the server (we faced such issue when there were 9Mil tasks)