### PR TITLE
Extended service information for non-consumer services

### DIFF
--- a/karton/core/backend.py
+++ b/karton/core/backend.py
@@ -361,7 +361,7 @@ class KartonBackend:
                     )
                     bound_services.append(service_info)
                 except Exception:
-                    logger.exception("Fatal error while parsing client name: ignoring")
+                    logger.exception("Fatal error while parsing client name: %s", name)
                     continue
         return bound_services
 

--- a/karton/core/backend.py
+++ b/karton/core/backend.py
@@ -119,7 +119,7 @@ class KartonBackend:
         )
 
     @staticmethod
-    def _validate_identity(identity: Optional[str]):
+    def _validate_identity(identity: str):
         disallowed_chars = [" ", "?"]
         if any(disallowed_char in identity for disallowed_char in disallowed_chars):
             raise InvalidIdentityError(
@@ -141,7 +141,7 @@ class KartonBackend:
         :return: Redis connection
         """
         if service_info is not None:
-            client_name = service_info.make_client_name()
+            client_name: Optional[str] = service_info.make_client_name()
         else:
             client_name = identity
 

--- a/karton/core/backend.py
+++ b/karton/core/backend.py
@@ -80,7 +80,7 @@ class KartonServiceInfo:
             for field in dataclasses.fields(cls)
             if field.metadata.get("serializable", True)
         ]
-        identity, params_string = client_name.split("?")
+        identity, params_string = client_name.split("?", 1)
         # Filter out unknown params to not get crashed by future extensions
         params = dict(
             [
@@ -333,7 +333,7 @@ class KartonBackend:
             name = client["name"]
             # Strip extra service information from client name
             if "?" in name:
-                name, _ = name.split("?")
+                name, _ = name.split("?", 1)
             bound_identities[name].append(client)
         return bound_identities
 

--- a/karton/core/backend.py
+++ b/karton/core/backend.py
@@ -1,6 +1,8 @@
+import dataclasses
 import enum
 import json
 import time
+import urllib.parse
 import warnings
 from collections import defaultdict, namedtuple
 from typing import IO, Any, Dict, Iterable, Iterator, List, Optional, Set, Tuple, Union
@@ -10,6 +12,7 @@ from redis import AuthenticationError, StrictRedis
 from redis.client import Pipeline
 from urllib3.response import HTTPResponse
 
+from .exceptions import InvalidIdentityError
 from .task import Task, TaskPriority, TaskState
 from .utils import chunks
 
@@ -19,7 +22,6 @@ KARTON_LOG_CHANNEL = "karton.log"
 KARTON_BINDS_HSET = "karton.binds"
 KARTON_TASK_NAMESPACE = "karton.task"
 KARTON_OUTPUTS_NAMESPACE = "karton.outputs"
-
 
 KartonBind = namedtuple(
     "KartonBind",
@@ -38,11 +40,66 @@ class KartonMetrics(enum.Enum):
     TASK_GARBAGE_COLLECTED = "karton.metrics.garbage-collected"
 
 
+@dataclasses.dataclass(frozen=True, order=True)
+class KartonServiceInfo:
+    """
+    Extended Karton service information.
+
+    Instances of this dataclass are meant to be aggregated to count service replicas
+    in Karton Dashboard. They're considered equal if identity, versions and extra_info
+    strings are the same.
+    """
+    identity: str = dataclasses.field(metadata={"serializable": False})
+    karton_version: str
+    service_version: Optional[str] = None
+    # Extra information about execution parameters etc.
+    extra_info: Optional[str] = None
+    # Extra information about Redis client
+    redis_client_info: Optional[Dict[str, str]] = dataclasses.field(
+        default=None, hash=False, compare=False, metadata={"serializable": False}
+    )
+
+    def make_client_name(self) -> str:
+        included_keys = [
+            field.name
+            for field in dataclasses.fields(self)
+            if field.metadata.get("serializable", True)
+        ]
+        params = {
+            k: v
+            for k, v in dataclasses.asdict(self).items()
+            if k in included_keys and v is not None
+        }
+        return f"{self.identity}?{urllib.parse.urlencode(params)}"
+
+    @classmethod
+    def parse_client_name(
+        cls, client_name: str, redis_client_info: Optional[Dict[str, str]] = None
+    ) -> "KartonServiceInfo":
+        identity, params_string = client_name.split("?")
+        params = dict(urllib.parse.parse_qsl(params_string))
+        return KartonServiceInfo(
+            identity, redis_client_info=redis_client_info, **params
+        )
+
+
 class KartonBackend:
-    def __init__(self, config, identity: Optional[str] = None) -> None:
+    def __init__(
+        self,
+        config,
+        identity: Optional[str] = None,
+        service_info: Optional[KartonServiceInfo] = None,
+    ) -> None:
         self.config = config
+
+        if identity is not None:
+            self._validate_identity(identity)
         self.identity = identity
-        self.redis = self.make_redis(config, identity=identity)
+
+        self.service_info = service_info
+        self.redis = self.make_redis(
+            config, identity=identity, service_info=service_info
+        )
         self.s3 = boto3.client(
             "s3",
             endpoint_url=config["s3"]["address"],
@@ -50,21 +107,40 @@ class KartonBackend:
             aws_secret_access_key=config["s3"]["secret_key"],
         )
 
-    def make_redis(self, config, identity: Optional[str] = None) -> StrictRedis:
+    @staticmethod
+    def _validate_identity(identity: Optional[str]):
+        disallowed_chars = [" ", "?"]
+        if any(disallowed_char in identity for disallowed_char in disallowed_chars):
+            raise InvalidIdentityError(
+                f"Karton identity should not contain {disallowed_chars}"
+            )
+
+    @staticmethod
+    def make_redis(
+        config,
+        identity: Optional[str] = None,
+        service_info: Optional[KartonServiceInfo] = None,
+    ) -> StrictRedis:
         """
         Create and test a Redis connection.
 
         :param config: The karton configuration
         :param identity: Karton service identity
+        :param service_info: Additional service identity metadata
         :return: Redis connection
         """
+        if service_info is not None:
+            client_name = service_info.make_client_name()
+        else:
+            client_name = identity
+
         redis_args = {
             "host": config["redis"]["host"],
             "port": config.getint("redis", "port", 6379),
             "db": config.getint("redis", "db", 0),
             "username": config.get("redis", "username"),
             "password": config.get("redis", "password"),
-            "client_name": identity,
+            "client_name": client_name,
             # set socket_timeout to None if set to 0
             "socket_timeout": config.getint("redis", "socket_timeout", 30) or None,
             "decode_responses": True,
@@ -232,16 +308,45 @@ class KartonBackend:
             DeprecationWarning,
         )
 
-    def get_online_consumers(self) -> Dict[str, List[str]]:
+    def get_online_consumers(self) -> Dict[str, List[Dict[str, str]]]:
         """
-        Gets all online consumer identities
+        Gets all online identities.
+
+        Actually this method returns all services having an identity,
+        so the list is not limited to consumers.
 
         :return: Dictionary {identity: [list of clients]}
         """
         bound_identities = defaultdict(list)
         for client in self.redis.client_list():
-            bound_identities[client["name"]].append(client)
+            name = client["name"]
+            # Strip extra service information from client name
+            if "?" in name:
+                name, _ = name.split("?")
+            bound_identities[name].append(client)
         return bound_identities
+
+    def get_online_services(self) -> List[KartonServiceInfo]:
+        """
+        Gets all online services providing extended service information.
+
+        Consumers by default don't provide that information and it's included in binds
+        instead. If you want to get information about all services, use
+        :py:meth:`KartonBackend.get_online_consumers`.
+
+        .. versionadded:: 5.1.0
+
+        :return: List of KartonServiceInfo objects
+        """
+        bound_services = []
+        for client in self.redis.client_list():
+            name = client["name"]
+            if "?" in name:
+                service_info = KartonServiceInfo.parse_client_name(
+                    name, redis_client_info=client
+                )
+                bound_services.append(service_info)
+        return bound_services
 
     def get_task(self, task_uid: str) -> Optional[Task]:
         """

--- a/karton/core/base.py
+++ b/karton/core/base.py
@@ -21,15 +21,17 @@ class KartonBase(abc.ABC):
     attribute.
     """
 
-    identity = ""
+    #: Karton service identity
+    identity: str = ""
+    #: Karton service version
     version: Optional[str] = None
+    #: Include extended service information for non-consumer services
     with_service_info: bool = False
 
     def __init__(
         self,
         config: Optional[Config] = None,
         identity: Optional[str] = None,
-        service_extra_info: Optional[str] = None,
         backend: Optional[KartonBackend] = None,
     ) -> None:
         self.config = config or Config()
@@ -48,7 +50,6 @@ class KartonBase(abc.ABC):
                 identity=self.identity,
                 karton_version=__version__,
                 service_version=self.version,
-                extra_info=service_extra_info,
             )
 
         self.backend = backend or KartonBackend(
@@ -195,10 +196,6 @@ class KartonServiceBase(KartonBase):
 
     :param config: Karton config to use for service configuration
     :param identity: Karton service identity to use
-    :param with_service_info: Include extended service information
-    :param service_extra_info: |
-        If with_service_info is enabled, includes extra information
-        to be displayed in Karton Dashboard
     :param backend: Karton backend to use
     """
 
@@ -206,13 +203,11 @@ class KartonServiceBase(KartonBase):
         self,
         config: Optional[Config] = None,
         identity: Optional[str] = None,
-        service_extra_info: Optional[str] = None,
         backend: Optional[KartonBackend] = None,
     ) -> None:
         super().__init__(
             config=config,
             identity=identity,
-            service_extra_info=service_extra_info,
             backend=backend,
         )
         self.setup_logger()

--- a/karton/core/exceptions.py
+++ b/karton/core/exceptions.py
@@ -1,3 +1,7 @@
+class InvalidIdentityError(Exception):
+    pass
+
+
 class TaskTimeoutError(Exception):
     pass
 

--- a/karton/core/karton.py
+++ b/karton/core/karton.py
@@ -55,9 +55,7 @@ class Producer(KartonBase):
         identity: Optional[str] = None,
         backend: Optional[KartonBackend] = None,
     ) -> None:
-        super(Producer, self).__init__(
-            config=config, identity=identity, backend=backend
-        )
+        super().__init__(config=config, identity=identity, backend=backend)
 
     def send_task(self, task: Task) -> bool:
         """
@@ -117,9 +115,7 @@ class Consumer(KartonServiceBase):
         identity: Optional[str] = None,
         backend: Optional[KartonBackend] = None,
     ) -> None:
-        super(Consumer, self).__init__(
-            config=config, identity=identity, backend=backend
-        )
+        super().__init__(config=config, identity=identity, backend=backend)
 
         if self.filters is None:
             raise ValueError("Cannot bind consumer on Empty binds")
@@ -358,6 +354,7 @@ class LogConsumer(KartonServiceBase):
 
     logger_filter: Optional[str] = None
     level: Optional[str] = None
+    with_service_info = True
 
     def __init__(
         self,
@@ -365,7 +362,7 @@ class LogConsumer(KartonServiceBase):
         identity: Optional[str] = None,
         backend: Optional[KartonBackend] = None,
     ) -> None:
-        super(LogConsumer, self).__init__(
+        super().__init__(
             config=config, identity=identity, backend=backend
         )
 
@@ -419,7 +416,7 @@ class Karton(Consumer, Producer):
         identity: Optional[str] = None,
         backend: Optional[KartonBackend] = None,
     ) -> None:
-        super(Karton, self).__init__(config=config, identity=identity, backend=backend)
+        super().__init__(config=config, identity=identity, backend=backend)
 
         if self.config.getboolean("signaling", "status", fallback=False):
             self.log.info("Using status signaling")

--- a/karton/core/karton.py
+++ b/karton/core/karton.py
@@ -362,9 +362,7 @@ class LogConsumer(KartonServiceBase):
         identity: Optional[str] = None,
         backend: Optional[KartonBackend] = None,
     ) -> None:
-        super().__init__(
-            config=config, identity=identity, backend=backend
-        )
+        super().__init__(config=config, identity=identity, backend=backend)
 
     @abc.abstractmethod
     def process_log(self, event: Dict[str, Any]) -> None:

--- a/karton/system/system.py
+++ b/karton/system/system.py
@@ -23,6 +23,7 @@ class SystemService(KartonServiceBase):
 
     identity = "karton.system"
     version = __version__
+    with_service_info = True
 
     GC_INTERVAL = 3 * 60
     TASK_DISPATCHED_TIMEOUT = 24 * 3600
@@ -30,8 +31,7 @@ class SystemService(KartonServiceBase):
     TASK_CRASHED_TIMEOUT = 3 * 24 * 3600
 
     def __init__(self, config: Optional[Config]) -> None:
-        super(SystemService, self).__init__(config=config)
-
+        self.config = config or Config()
         self.gc_interval = self.config.getint("system", "gc_interval", self.GC_INTERVAL)
         self.task_dispatched_timeout = self.config.getint(
             "system", "task_dispatched_timeout", self.TASK_DISPATCHED_TIMEOUT
@@ -46,6 +46,9 @@ class SystemService(KartonServiceBase):
         self.enable_router = self.config.getboolean("system", "enable_router", True)
 
         self.last_gc_trigger = time.time()
+
+        service_extra_info = f"GC enabled: {self.enable_gc}, routing enabled: {self.enable_router}"
+        super().__init__(config=config, service_extra_info=service_extra_info)
 
     def gc_collect_resources(self) -> None:
         # Collects unreferenced resources left in object storage

--- a/karton/system/system.py
+++ b/karton/system/system.py
@@ -31,7 +31,7 @@ class SystemService(KartonServiceBase):
     TASK_CRASHED_TIMEOUT = 3 * 24 * 3600
 
     def __init__(self, config: Optional[Config]) -> None:
-        self.config = config or Config()
+        super().__init__(config=config)
         self.gc_interval = self.config.getint("system", "gc_interval", self.GC_INTERVAL)
         self.task_dispatched_timeout = self.config.getint(
             "system", "task_dispatched_timeout", self.TASK_DISPATCHED_TIMEOUT
@@ -46,9 +46,6 @@ class SystemService(KartonServiceBase):
         self.enable_router = self.config.getboolean("system", "enable_router", True)
 
         self.last_gc_trigger = time.time()
-
-        service_extra_info = f"GC enabled: {self.enable_gc}, routing enabled: {self.enable_router}"
-        super().__init__(config=config, service_extra_info=service_extra_info)
 
     def gc_collect_resources(self) -> None:
         # Collects unreferenced resources left in object storage


### PR DESCRIPTION
It would be nice to have version information also for looping producers (feeders), log consumers and other services that are part of Karton pipeline.

In this PR I'm adding these informations as a part of client name in the following URI like format:
```
karton.producer?karton_version=5.1.0&service_version=1.0.0
```

Client name is currently used only by consumers to count the replicas and track for abandoned non-persistent queues, so it's not a breaking change if we include extra information for non-consumers. Information is included to client name only if `KartonBase.with_service_info` class attribute is set to True (False by default).

Attached version information can be then displayed in Karton Dashboard (see also https://github.com/CERT-Polska/karton-dashboard/pull/72)

![image](https://user-images.githubusercontent.com/8720367/220373669-e110d0cc-58e0-4d2b-8d86-967548481953.png)
