### PR TITLE
Allow dashes in config section names configured by env

### DIFF
--- a/karton/core/config.py
+++ b/karton/core/config.py
@@ -219,7 +219,7 @@ class Config(object):
         for name, value in os.environ.items():
             # Load env variables named KARTON_[section]_[key]
             # to match ConfigParser structure
-            result = re.fullmatch(r"KARTON_([A-Z0-9]+)_([A-Z0-9_]+)", name)
+            result = re.fullmatch(r"KARTON_([A-Z0-9-]+)_([A-Z0-9_]+)", name)
 
             if not result:
                 continue


### PR DESCRIPTION
It will allow us to configure sections like `archive-unpacker` and `mwdb-reporter` using the environmental variables.