### PR TITLE
Docs: Update broken link in 'Getting Started'

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -42,7 +42,7 @@ If everything was configured correctly, you should now be able to run the ``kart
 Docker Compose development setup
 --------------------------------
 
-Check out repository called `Karton playground <github.com/CERT-Polska/karton-playground/>`_ that provides similar setup coupled with MWDB Core
+Check out repository called `Karton playground <https://github.com/CERT-Polska/karton-playground/>`_ that provides similar setup coupled with MWDB Core
 and few open-source Karton services.
 
 If you're just trying Karton out or you want a mimimal, quick & easy development environment setup, check out the ``dev`` folder in the Karton root directory.


### PR DESCRIPTION
Before this change it was rendering to `https://karton-core.readthedocs.io/en/latest/github.com/CERT-Polska/karton-playground/` :face_with_head_bandage: 