### PR TITLE
Feature: persistent headers

### DIFF
--- a/docs/task_headers_payloads.rst
+++ b/docs/task_headers_payloads.rst
@@ -358,15 +358,15 @@ Persistent headers
 
 .. versionadded:: 5.2.0
 
-Headers that are propagated to the whole task subtree, so consumers don't need to care about passing these things to child tasks.
+Headers that are propagated to the whole task subtree, so consumers don't need to remember about passing these values to child tasks.
 
 Using persistent headers you can mark properties that are crucial for routing and should be kept for analysis artifacts as well:
 
 * Analysis volatility if we don't want to report and persist artifacts from analysis, so tasks are not routed to reporter services
 * Analysis confidentiality if we shouldn't pass artifacts to 3rd party services and they should be considered internal
-* Marking analysis as made for testing, so we can pass only testing analyses to testing consumers
+* Marking analysis as test cases, so we can pass only testing analyses to testing consumers
 
-Semantics are similar as for persistent payload:
+Semantics are similar to persistent payload:
 
 .. code-block:: python
 
@@ -387,4 +387,4 @@ Headers precedence is as follows:
 * ``headers_persistent`` from current task
 * ``headers`` from current task (least important)
 
-Following these rules: persistent headers are propagating to the whole subtree and always override other headers with the same key.
+Following these rules: persistent headers propagate to the whole subtree and always override other headers with the same key.

--- a/docs/task_headers_payloads.rst
+++ b/docs/task_headers_payloads.rst
@@ -352,3 +352,39 @@ Regular payloads and persistent payload keys have common namespace so persistent
     Because merging strategy is quite aggressive, it's not recommended to overuse that feature. They should be treated as "analysis-wide payload". It's recommended to set them only in initial task.
     
     Don't store any references to resources or other heavy objects here, unless you need to. Persistent payload is, as the name says, persistent, so it is propagated to the whole task subtree and **can't be removed** during analysis. Resource referenced by persistent payload won't be garbage-collected until the whole analysis (task subtree) ends, even if it's not needed by further analysis steps.
+
+Persistent headers
+------------------
+
+.. versionadded:: 5.2.0
+
+Headers that are propagated to the whole task subtree, so consumers don't need to care about passing these things to child tasks.
+
+Using persistent headers you can mark properties that are crucial for routing and should be kept for analysis artifacts as well:
+
+* Analysis volatility if we don't want to report and persist artifacts from analysis, so tasks are not routed to reporter services
+* Analysis confidentiality if we shouldn't pass artifacts to 3rd party services and they should be considered internal
+* Marking analysis as made for testing, so we can pass only testing analyses to testing consumers
+
+Semantics are similar as for persistent payload:
+
+.. code-block:: python
+
+    task = Task(
+        headers=...,
+        payload=...,
+        headers_persistent={
+            "uploader": "psrok1"
+        }
+    )
+
+
+``headers_persistent`` passed to Task are merged with ``self.headers`` with keys marked internally as persistent.
+
+Headers precedence is as follows:
+
+* ``headers_persistent`` from parent task (most important)
+* ``headers_persistent`` from current task
+* ``headers`` from current task (least important)
+
+Following these rules: persistent headers are propagating to the whole subtree and always override other headers with the same key.

--- a/karton/core/karton.py
+++ b/karton/core/karton.py
@@ -71,6 +71,7 @@ class Producer(KartonBase):
         if self.current_task is not None:
             task.set_task_parent(self.current_task)
             task.merge_persistent_payload(self.current_task)
+            task.merge_persistent_headers(self.current_task)
             task.priority = self.current_task.priority
 
         task.last_update = time.time()

--- a/karton/core/task.py
+++ b/karton/core/task.py
@@ -112,9 +112,7 @@ class Task(object):
 
     @property
     def headers_persistent(self) -> Dict[str, Any]:
-        return {
-            k: v for k, v in self.headers.items() if self.is_header_persistent(k)
-        }
+        return {k: v for k, v in self.headers.items() if self.is_header_persistent(k)}
 
     def fork_task(self) -> "Task":
         """

--- a/karton/core/task.py
+++ b/karton/core/task.py
@@ -113,7 +113,7 @@ class Task(object):
     @property
     def headers_persistent(self) -> Dict[str, Any]:
         return {
-            k: v for k, v in self.headers.items() if k in self._headers_persistent_keys
+            k: v for k, v in self.headers.items() if self.is_header_persistent(k)
         }
 
     def fork_task(self) -> "Task":


### PR DESCRIPTION
Reasons to implement that:

- They make a good place for "properties" idea from https://github.com/CERT-Polska/karton/issues/167. 
- It's also follow up from https://github.com/CERT-Polska/mwdb-core/pull/801 as we don't propagate `share_3rd_party` header within karton-archive-extractor. 
- Another painful header is `quality` that needs to be passed manually from task to task: https://github.com/CERT-Polska/karton-classifier/blob/master/karton/classifier/classifier.py#L102

Few design details:

- They follow the same semantics as persistent payloads, but both persistent and non-persistent headers are available from the same dict to keep it easier for users. Both internal and service code tends to directly modify `self.headers` collection so it was important also for compatibility.
- Copy of `headers_persistent` goes to the serialized JSON as well. Values contained there always take precedence over `headers`, so it should be consistent.
- For compatibility: we need to keep a copy in `payload_persistent`, because older consumer making a new `Task(...)` will pass headers without persistent ones so they will be lost. As we keep it in `payload_persistent`, they will be placed back in `headers_persistent` during deserialization made by `karton.system` 
