### PR TITLE
Update producer example in docs

### DIFF
--- a/docs/service_examples.rst
+++ b/docs/service_examples.rst
@@ -9,7 +9,9 @@ Producer services
 
 .. code-block:: python
 
+    import os
     import sys
+    import logging
     from karton.core import Config, Producer, Task, Resource
 
     config = Config("karton.ini")
@@ -23,11 +25,11 @@ Producer services
 
     task = Task({"type": "sample", "kind": "raw"})
 
-    task.add_resource("sample", resource)
+    task.add_payload("sample", resource)
     task.add_payload("tags", ["simple_producer"])
     task.add_payload("additional_info", ["This sample has been added by simple producer example"])
 
-    logging.info('pushing file to karton %s, task %s' % (name, task))
+    logging.info('pushing file to karton: %s, task: %s' % (filename, task))
     producer.send_task(task)
 
    


### PR DESCRIPTION
Recently needed functionality similar to the Producer example code, copy pasted it and found it is outdated and broken.

* Add missing imports
* Fix `name` -> `filename` for the code to run
* Use `add_payload` as `add_resource` as been deprecated