### PR TITLE
Introduce karton debug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ karton.ini
 config.ini
 docs/_build
 .mypy_cache
+build
+karton_core.egg-info/

--- a/docs/advanced_concepts.rst
+++ b/docs/advanced_concepts.rst
@@ -244,5 +244,5 @@ It also permanently sets the consumer persistence to False and disables log forw
 
 You can enable it by setting:
 - :code:`KARTON_KARTON_DEBUG` environment value to "1"
-- :code:`[debug]` parameter to `1` in the :code:`[karton]` config section
+- :code:`debug` parameter to `1` in the :code:`[karton]` config section
 - :code:`--debug` command-line parameter

--- a/docs/advanced_concepts.rst
+++ b/docs/advanced_concepts.rst
@@ -230,3 +230,19 @@ The simplest way to do that is to perform all of these actions synchronously, in
         # If analysis has been finished: get the results and process them
         analysis = sandbox.get_results(analysis_id)
         self.process_results(analysis)
+
+
+Karton debug mode
+-----------------
+
+During your karton services development endeavours you'll often have the urge to test them out on the production environment.
+
+While this is totally fine you have to be careful not to disrupt the production services by consuming the tasks meant for them.
+
+Karton debug mode was crafted especially for this purpose. It adds a random suffix to the service identity to create a new, non-conflicting task queue.
+It also permanently sets the consumer persistence to False and disables log forwarding.
+
+You can enable it by setting:
+- :code:`KARTON_KARTON_DEBUG` environment value
+- :code:`[debug]` parameter in the :code:`[karton]` config section
+- :code:`--debug` command-line parameter

--- a/docs/service_configuration.rst
+++ b/docs/service_configuration.rst
@@ -48,6 +48,7 @@ Common Karton configuration fields are listed below:
  [redis]        socket_timeout    Socket timeout for Redis operations in seconds (default: 30, use 0 to turn off if timeout doesn't work properly)
  [karton]       identity          Karton service identity override (overrides the name provided in class / constructor arguments)
  [karton]       persistent        Karton service queue persistency override
+ [karton]       debug             Karton debug mode for service development
  [karton]       task_timeout      Karton service task execution timeout in seconds. Useful if your service sometimes hangs. Karton will schedule SIGALRM if this value is set.
  [logging]      level             Logging level for Karton service logger (default: INFO)
  [signaling]    status            Turns on producing of 'karton.signaling.status' tasks, signalling the task start and finish events by Karton service (default: 0, off)
@@ -90,6 +91,7 @@ All settings can be set using command-line.
       --identity IDENTITY   Alternative identity for Karton service
       --log-level LOG_LEVEL
                             Logging level of Karton logger
+      --debug               Enable debugging mode
       --setup-bucket        Create missing bucket in S3 storage
       --disable-gc          Do not run GC in this instance
       --disable-router      Do not run task routing in this instance

--- a/karton/core/base.py
+++ b/karton/core/base.py
@@ -9,7 +9,7 @@ from typing import Optional, Union, cast
 from .__version__ import __version__
 from .backend import KartonBackend, KartonServiceInfo
 from .config import Config
-from .logger import KartonLogHandler, KartonLogDebugHandler
+from .logger import KartonLogHandler
 from .task import Task
 from .utils import HardShutdownInterrupt, StrictClassMethod, graceful_killer
 

--- a/karton/core/base.py
+++ b/karton/core/base.py
@@ -1,7 +1,7 @@
 import abc
-import os
 import argparse
 import logging
+import os
 import textwrap
 from contextlib import contextmanager
 from typing import Optional, Union, cast

--- a/karton/core/base.py
+++ b/karton/core/base.py
@@ -45,7 +45,7 @@ class KartonBase(abc.ABC):
         if self.config.has_option("karton", "identity"):
             self.identity = self.config.get("karton", "identity")
 
-        self.debug = self.config.getboolean("karton", "debug")
+        self.debug = self.config.getboolean("karton", "debug", False)
 
         if self.debug:
             self.identity += "-" + os.urandom(4).hex() + "-dev"

--- a/karton/core/base.py
+++ b/karton/core/base.py
@@ -162,6 +162,9 @@ class KartonBase(abc.ABC):
             "--identity", help="Alternative identity for Karton service"
         )
         parser.add_argument("--log-level", help="Logging level of Karton logger")
+        parser.add_argument(
+            "--debug", help="Enable debugging mode", action="store_true", default=None
+        )
         return parser
 
     @classmethod
@@ -174,7 +177,10 @@ class KartonBase(abc.ABC):
         """
         config.load_from_dict(
             {
-                "karton": {"identity": args.identity},
+                "karton": {
+                    "identity": args.identity,
+                    "debug": args.debug,
+                },
                 "logging": {"level": args.log_level},
             }
         )

--- a/karton/core/karton.py
+++ b/karton/core/karton.py
@@ -123,7 +123,7 @@ class Consumer(KartonServiceBase):
 
         self.persistent = self.config.getboolean(
             "karton", "persistent", self.persistent
-        )
+        ) and not self.debug
         self.task_timeout = self.config.getint("karton", "task_timeout")
         self.current_task: Optional[Task] = None
         self._pre_hooks: List[Tuple[Optional[str], Callable[[Task], None]]] = []

--- a/karton/core/karton.py
+++ b/karton/core/karton.py
@@ -121,9 +121,10 @@ class Consumer(KartonServiceBase):
         if self.filters is None:
             raise ValueError("Cannot bind consumer on Empty binds")
 
-        self.persistent = self.config.getboolean(
-            "karton", "persistent", self.persistent
-        ) and not self.debug
+        self.persistent = (
+            self.config.getboolean("karton", "persistent", self.persistent)
+            and not self.debug
+        )
         self.task_timeout = self.config.getint("karton", "task_timeout")
         self.current_task: Optional[Task] = None
         self._pre_hooks: List[Tuple[Optional[str], Callable[[Task], None]]] = []


### PR DESCRIPTION
The karton debug mode helps with developing karton services while connected to the production karton network. It does that by:

* appending a random suffix to the karton service identity to avoid disrupting production services
* permanently setting the `persistent` attribute to False - the bind will disappear after the service quits
* not sending the (error) logs to karton listeners - this will help you to avoid spamming logging services in your deployment

The debug mode works as any other karton configuartion and can be set by:
* setting the env value `KARTON_KARTON_DEBUG=1`
* setting `debug=1` in the `karton` section in `karton.ini`
* passing `--debug` to karton services via cli