### PR TITLE
Fix issue #222 with matches_filters method

### DIFF
--- a/karton/core/task.py
+++ b/karton/core/task.py
@@ -241,7 +241,7 @@ class Task(object):
                 matched.append(match != negated)
 
             # set the flag if all consumer filter fields match the task header.
-            # It wil be set to True only if at least one filter matches the header
+            # It will be set to True only if at least one filter matches the header
             matches |= all(m for m in matched)
 
         return matches

--- a/karton/core/task.py
+++ b/karton/core/task.py
@@ -212,32 +212,38 @@ class Task(object):
         :meta private:
         """
 
-        def value_compare(filter_value: Any, header_value: Any) -> bool:
-            # Coerce to string for comparison
-            filter_value_str = str(filter_value)
-            header_value_str = str(header_value)
+        matches = False
+        for task_filter in filters:
+            matched = []
+            for filter_key, filter_value in task_filter.items():
+                # Coerce to string for comparison
+                header_value = self.headers.get(filter_key)
+                filter_value_str = str(filter_value)
+                header_value_str = str(header_value)
 
-            negated = False
-            if filter_value_str.startswith("!"):
-                negated = True
-                filter_value_str = filter_value_str[1:]
+                negated = False
+                if filter_value_str.startswith("!"):
+                    negated = True
+                    filter_value_str = filter_value_str[1:]
 
-            if header_value is None:
-                return negated
+                if header_value is None:
+                    matched.append(negated)
+                    continue
 
-            # fnmatch is great for handling simple wildcard patterns (?, *, [abc])
-            # If negated: match result should not be True (XOR)
-            return fnmatch.fnmatchcase(header_value_str, filter_value_str) != negated
+                # fnmatch is great for handling simple wildcard patterns (?, *, [abc])
+                match = fnmatch.fnmatchcase(header_value_str, filter_value_str)
+                # if matches, but it's negated then we can return straight away since no matter the other filters
+                if match and negated:
+                    return False
 
-        return any(
-            # If any of consumer filters matches the header
-            all(
-                # Match: all consumer filter fields match the task header
-                value_compare(filter_value, self.headers.get(filter_key))
-                for filter_key, filter_value in task_filter.items()
-            )
-            for task_filter in filters
-        )
+                # else, apply a XOR logic to take care of negation matching
+                matched.append(match != negated)
+
+            # set the flag if all consumer filter fields match the task header.
+            # It wil be set to True only if at least one filter matches the header
+            matches |= all(m for m in matched)
+
+        return matches
 
     def set_task_parent(self, parent: "Task"):
         """

--- a/karton/core/task.py
+++ b/karton/core/task.py
@@ -232,7 +232,8 @@ class Task(object):
 
                 # fnmatch is great for handling simple wildcard patterns (?, *, [abc])
                 match = fnmatch.fnmatchcase(header_value_str, filter_value_str)
-                # if matches, but it's negated then we can return straight away since no matter the other filters
+                # if matches, but it's negated then we can return straight away
+                # since no matter the other filters
                 if match and negated:
                     return False
 

--- a/tests/test_task_filters.py
+++ b/tests/test_task_filters.py
@@ -61,6 +61,10 @@ class TestTaskFilters(unittest.TestCase):
         filters = [
             {
                 "type": "sample",
+                "platform": "!macos"
+            },
+            {
+                "type": "sample",
                 "platform": "!win*"
             }
         ]


### PR DESCRIPTION
Issue reported here: https://github.com/CERT-Polska/karton/issues/222

I have just refactored the code in order to keep the matching logic the same and at the same time to take into account the use case that is causing the wrong matching when filters have more negated fields that matches the headers values.

I have also updated the unittest related to the task filters with negation.

```
In [1]: from karton.core import Task
In [2]: Task({
   ...:     "type": "sample",
   ...:     "kind": "runnable",
   ...:     "platform": "win32",
   ...:     "extension": "msix"
   ...: }).matches_filters([
   ...:         {"type": "sample", "kind": "runnable", "platform": "win*", "extension": "!msi*"},
   ...:         {"type": "sample", "kind": "runnable", "platform": "win*", "extension": "!lnk"},
   ...:         {"type": "sample", "kind": "document", "platform": "win*"}
   ...:     ])
   ...: 
Out[2]: False
```

```
$ python -m unittest discover tests/
.............
----------------------------------------------------------------------
Ran 13 tests in 0.040s

OK
```
