### PR TITLE
CI: Fix lint-python after Redis v5.0.0 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,5 @@ line_length = 88
 [tool.lint-python]
 lint-version = "2"
 source = "karton/"
+# Temporary workaround for Union[Awaitable[T]], T] mess in Redis typing
+extra-requirements = "redis<5.0.0"


### PR DESCRIPTION
Redis-py laziness in defining types results in the following errors:
```
karton/core/backend.py:276: error: Argument 2 to "unserialize_bind" of "KartonBackend" has incompatible type "Union[Awaitable[Optional[str]], str, None]"; expected "str"
karton/core/backend.py:287: error: Item "Awaitable[Dict[Any, Any]]" of "Union[Awaitable[Dict[Any, Any]], Dict[Any, Any]]" has no attribute "items"
karton/core/backend.py:287: note: Maybe you forgot to use "await"?
karton/core/backend.py:312: error: Argument 2 to "hdel" of "HashCommands" has incompatible type "str"; expected "List[Any]"
karton/core/backend.py:334: error: Item "Awaitable[Any]" of "Union[Awaitable[Any], Any]" has no attribute "__iter__" (not iterable)
karton/core/backend.py:355: error: Item "Awaitable[Any]" of "Union[Awaitable[Any], Any]" has no attribute "__iter__" (not iterable)
karton/core/backend.py:378: error: Argument 1 to "unserialize" of "Task" has incompatible type "Union[Awaitable[Any], Any]"; expected "Union[str, bytes]"
karton/core/backend.py:405: error: Item "Awaitable[Any]" of "Union[Awaitable[Any], Any]" has no attribute "__iter__" (not iterable)
karton/core/backend.py:420: error: Item "Awaitable[Any]" of "Union[Awaitable[Any], Any]" has no attribute "__iter__" (not iterable)
karton/core/backend.py:559: error: Argument 1 to "get_tasks" of "KartonBackend" has incompatible type "Union[Awaitable[List[Any]], List[Any]]"; expected "List[str]"
karton/core/backend.py:568: error: Incompatible return value type (got "Union[Awaitable[List[Any]], List[Any]]", expected "List[str]")
karton/core/backend.py:626: error: Incompatible return value type (got "Union[Awaitable[List[Any]], List[Any]]", expected "Optional[Tuple[str, str]]")
karton/core/backend.py:626: error: Argument 1 to "blpop" of "ListCommands" has incompatible type "Union[str, List[str]]"; expected "List[Any]"
karton/core/backend.py:717: error: Unsupported operand types for < ("int" and "Awaitable[Any]")
karton/core/backend.py:717: note: Left operand is of type "Union[Awaitable[Any], Any]"
karton/core/backend.py:806: error: Item "Awaitable[Dict[Any, Any]]" of "Union[Awaitable[Dict[Any, Any]], Dict[Any, Any]]" has no attribute "items"
karton/core/backend.py:806: note: Maybe you forgot to use "await"?
karton/core/backend.py:944: error: Argument 2 to "unserialize_output" of "KartonBackend" has incompatible type "Union[Awaitable[Set[Any]], Set[Any]]"; expected "Set[str]"
karton/core/backend.py:946: error: Item "Awaitable[Any]" of "Union[Awaitable[Any], Any]" has no attribute "__iter__" (not iterable)
```

As a temporary workaround, I would pin to `redis<5.0.0` for linting and fix it somehow in the next versions.