### PR TITLE
Require Python >=3.8 and fix readthedocs configuration

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,9 +3,10 @@ sphinx:
   configuration: docs/conf.py
 formats:
   - pdf
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
 python:
-  version: 3.6
   install:
-    - method: pip
-      path: .
     - requirements: docs/requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,9 @@ setup(
     },
     url="https://github.com/CERT-Polska/karton",
     classifiers=[
-        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
         "Operating System :: OS Independent",
         "License :: OSI Approved :: BSD License",
     ],
+    python_requires='>=3.8',
 )


### PR DESCRIPTION
Right now RTD fails with:
![image](https://github.com/CERT-Polska/karton/assets/8720367/83eb8952-9150-4a21-bd6c-071482be2371)
