### PR TITLE
Fix IAM token expiration

### DIFF
--- a/karton/core/backend.py
+++ b/karton/core/backend.py
@@ -152,7 +152,7 @@ class KartonBackend:
                     boto_session._credentials = creds  # type: ignore
                     break
 
-        creds_loaded = boto_session._credentials is not None
+        creds_loaded = boto_session._credentials is not None  # type: ignore
 
         if not iam_auth or not creds_loaded:
             if access_key is None or secret_key is None:

--- a/karton/core/backend.py
+++ b/karton/core/backend.py
@@ -14,7 +14,6 @@ from botocore.credentials import (
     InstanceMetadataFetcher,
     InstanceMetadataProvider,
 )
-from botocore.client import S3
 from botocore.session import get_session
 from redis import AuthenticationError, StrictRedis
 from redis.client import Pipeline
@@ -154,7 +153,7 @@ class KartonBackend:
             aws_secret_access_key=secret_key,
         )
 
-    def iam_auth_s3(self, endpoint: str) -> Optional[S3]:
+    def iam_auth_s3(self, endpoint: str):
         boto_session = get_session()
         iam_providers = [
             ContainerProvider(),

--- a/karton/core/backend.py
+++ b/karton/core/backend.py
@@ -14,6 +14,7 @@ from botocore.credentials import (
     InstanceMetadataFetcher,
     InstanceMetadataProvider,
 )
+from botocore.client import S3
 from botocore.session import get_session
 from redis import AuthenticationError, StrictRedis
 from redis.client import Pipeline
@@ -153,7 +154,7 @@ class KartonBackend:
             aws_secret_access_key=secret_key,
         )
 
-    def iam_auth_s3(self, endpoint: str) -> Optional[botocore.client.S3]:
+    def iam_auth_s3(self, endpoint: str) -> Optional[S3]:
         boto_session = get_session()
         iam_providers = [
             ContainerProvider(),

--- a/karton/core/backend.py
+++ b/karton/core/backend.py
@@ -153,7 +153,7 @@ class KartonBackend:
             aws_secret_access_key=secret_key,
         )
 
-    def iam_auth_s3(self, endpoint: str):
+    def iam_auth_s3(self, endpoint: str) -> Optional[botocore.client.S3]:
         boto_session = get_session()
         iam_providers = [
             ContainerProvider(),


### PR DESCRIPTION
This PR solves the issue described in #233. Botocore's `*Provider` classes such as `ContainerProvider` return a `RefreshableCredentials` object when calling their `load` method. This object knows when and how to refresh the session token, so there's no need to implement custom code to do that. In current code, this object is thrown away so it gets no chance to auto-refresh the token.

Instead, use a lower level session object and if possible, attach this `RefreshableCredentials` object to it, and create the s3 client from it. 

Tested on MWDB v2.10.2 with a karton that uses v5.3.0 of karton-core with the diff in this PR patched into it and seems to still work even a couple of hours after the karton is up (whereas the current code fails). Kept as draft until I'm sure it solves the issue

Fixes #233 