### PR TITLE
Fix issues with `register_tasks` and empty tasks list

### DIFF
--- a/karton/core/backend.py
+++ b/karton/core/backend.py
@@ -544,6 +544,10 @@ class KartonBackend:
         Register or update multiple tasks in Redis.
         :param tasks: List of task objects
         """
+        # calling mset with an empty dictionary results in a crash
+        if not tasks:
+            return
+
         taskmap = {
             f"{KARTON_TASK_NAMESPACE}:{task.uid}": task.serialize() for task in tasks
         }


### PR DESCRIPTION
Closes #236 

When `backend.register_tasks` - https://github.com/CERT-Polska/karton/blob/2d10bd432928354a2030a0ee8aa976b64f4acb63/karton/core/backend.py#L542 is called with an empty list of tasks to create it results in a crash when calling `mset`:

`redis.exceptions.ResponseError: wrong number of arguments for 'mset' command`

Reproduction:
Downgrade to <4.4.0, create a new task and create a new "NOP" operational task by setting the task status to its current value:

```python
producer = Producer(identity="test-producer")
headers = {
    "kind": "raw",
    "type": "sample"
}
t = Task(headers=headers, payload={
    "sample": "sample",
})
producer.send_task(t)
producer.backend.set_task_status(t, TaskState.DECLARED)
```