### PR TITLE
TaskTimeoutError should be BaseException instead of Exception

### DIFF
--- a/karton/core/exceptions.py
+++ b/karton/core/exceptions.py
@@ -2,7 +2,7 @@ class InvalidIdentityError(Exception):
     pass
 
 
-class TaskTimeoutError(Exception):
+class TaskTimeoutError(BaseException):
     pass
 
 


### PR DESCRIPTION
Task timeout function sets alarm that triggers SIGALRM, which is then handled by throwing TaskTimeoutError. This mechanism should crash task that is running too long e.g. because of infinite loop or other conditon that caused the consumer to be hanged.

Unfortunately, TaskTimeoutError derives from Exception base class which means that it will be cached by any `try..except` clause that catches all Exceptions, which is pretty common pattern in Python, making timeout ineffective. This kind of situation happens in karton-config-extractor and malduck: https://github.com/CERT-Polska/malduck/blob/master/malduck/extractor/extractor.py#L447

This PR changes base class of TaskTimeoutError from Exception to BaseException (like GracefulShutdown).

> BaseException is the common base class of all exceptions. One of its subclasses, [Exception](https://docs.python.org/3/library/exceptions.html#Exception), is the base class of all the non-fatal exceptions. [Exception](https://docs.python.org/3/library/exceptions.html#Exception)s which are not subclasses of Exception are not typically handled, because they are used to indicate that the program should terminate. They include [SystemExit](https://docs.python.org/3/library/exceptions.html#SystemExit) which is raised by [sys.exit()](https://docs.python.org/3/library/sys.html#sys.exit) and [KeyboardInterrupt](https://docs.python.org/3/library/exceptions.html#KeyboardInterrupt) which is raised when a user wishes to interrupt the program.
> from https://docs.python.org/3/tutorial/errors.html