### PR TITLE
Use error instead of warning when tasks are killed due to inactivity

### DIFF
--- a/karton/system/system.py
+++ b/karton/system/system.py
@@ -103,7 +103,7 @@ class SystemService(KartonServiceBase):
                 and current_time > task.last_update + self.task_dispatched_timeout
             ):
                 to_delete.append(task)
-                self.log.warning(
+                self.log.error(
                     "Task %s is in Dispatched state more than %d seconds. "
                     "Killed. (origin: %s)",
                     task.uid,
@@ -116,7 +116,7 @@ class SystemService(KartonServiceBase):
                 and current_time > task.last_update + self.task_started_timeout
             ):
                 to_delete.append(task)
-                self.log.warning(
+                self.log.error(
                     "Task %s is in Started state more than %d seconds. "
                     "Killed. (receiver: %s)",
                     task.uid,


### PR DESCRIPTION
Those two scenarios shouldn't happen in a "healthy" environment. By using error instead of warning they will be easier to spot and resolve.