### PR TITLE
Log timeouts as errors (except the crashed timeout)

### DIFF
--- a/karton/system/system.py
+++ b/karton/system/system.py
@@ -103,7 +103,7 @@ class SystemService(KartonServiceBase):
                 and current_time > task.last_update + self.task_dispatched_timeout
             ):
                 to_delete.append(task)
-                self.log.warning(
+                self.log.error(
                     "Task %s is in Dispatched state more than %d seconds. "
                     "Killed. (origin: %s)",
                     task.uid,
@@ -116,7 +116,7 @@ class SystemService(KartonServiceBase):
                 and current_time > task.last_update + self.task_started_timeout
             ):
                 to_delete.append(task)
-                self.log.warning(
+                self.log.error(
                     "Task %s is in Started state more than %d seconds. "
                     "Killed. (receiver: %s)",
                     task.uid,
@@ -132,7 +132,7 @@ class SystemService(KartonServiceBase):
                 and current_time > task.last_update + self.task_crashed_timeout
             ):
                 to_delete.append(task)
-                self.log.debug(
+                self.log.warning(
                     "GC: Task %s is in Crashed state more than %d seconds. "
                     "Killed. (receiver: %s)",
                     task.uid,


### PR DESCRIPTION
Timeouts may be a very serious problem, and because of the low log levels we sometimes miss them.