### PR TITLE
Fix TaskTimeoutException regression

### DIFF
--- a/karton/core/karton.py
+++ b/karton/core/karton.py
@@ -17,6 +17,8 @@ from .resource import LocalResource
 from .task import Task, TaskState
 from .utils import timeout
 
+KartonTaskException = Union[Exception, BaseException]
+
 
 class Producer(KartonBase):
     """
@@ -132,7 +134,7 @@ class Consumer(KartonServiceBase):
         self._post_hooks: List[
             Tuple[
                 Optional[str],
-                Callable[[Task, Optional[Union[Exception, BaseException]]], None],
+                Callable[[Task, Optional[KartonTaskException]], None],
             ]
         ] = []
 
@@ -264,7 +266,7 @@ class Consumer(KartonServiceBase):
 
     def add_post_hook(
         self,
-        callback: Callable[[Task, Optional[Exception]], None],
+        callback: Callable[[Task, Optional[KartonTaskException]], None],
         name: Optional[str] = None,
     ) -> None:
         """
@@ -293,9 +295,7 @@ class Consumer(KartonServiceBase):
                 else:
                     self.log.exception("Pre-hook failed")
 
-    def _run_post_hooks(
-        self, exception: Optional[Union[Exception, BaseException]]
-    ) -> None:
+    def _run_post_hooks(self, exception: Optional[KartonTaskException]) -> None:
         """
         Run registered postprocessing hooks
 

--- a/karton/core/karton.py
+++ b/karton/core/karton.py
@@ -12,6 +12,7 @@ from .__version__ import __version__
 from .backend import KartonBackend, KartonBind, KartonMetrics
 from .base import KartonBase, KartonServiceBase
 from .config import Config
+from .exceptions import TimeoutException
 from .resource import LocalResource
 from .task import Task, TaskState
 from .utils import timeout
@@ -179,14 +180,14 @@ class Consumer(KartonServiceBase):
                         self.process(self.current_task)
                 else:
                     self.process(self.current_task)
-            except Exception as exc:
+            except (Exception, TimeoutException) as exc:
                 saved_exception = exc
                 raise
             finally:
                 self._run_post_hooks(saved_exception)
 
             self.log.info("Task done - %s", self.current_task.uid)
-        except Exception:
+        except (Exception, TimeoutException):
             exc_info = sys.exc_info()
             exception_str = traceback.format_exception(*exc_info)
 

--- a/karton/core/karton.py
+++ b/karton/core/karton.py
@@ -18,7 +18,6 @@ from .task import Task, TaskState
 from .utils import timeout
 
 
-
 class Producer(KartonBase):
     """
     Producer part of Karton. Used for dispatching initial tasks into karton.

--- a/karton/core/karton.py
+++ b/karton/core/karton.py
@@ -12,7 +12,7 @@ from .__version__ import __version__
 from .backend import KartonBackend, KartonBind, KartonMetrics
 from .base import KartonBase, KartonServiceBase
 from .config import Config
-from .exceptions import TimeoutException
+from .exceptions import TaskTimeoutError
 from .resource import LocalResource
 from .task import Task, TaskState
 from .utils import timeout
@@ -180,14 +180,14 @@ class Consumer(KartonServiceBase):
                         self.process(self.current_task)
                 else:
                     self.process(self.current_task)
-            except (Exception, TimeoutException) as exc:
+            except (Exception, TaskTimeoutError) as exc:
                 saved_exception = exc
                 raise
             finally:
                 self._run_post_hooks(saved_exception)
 
             self.log.info("Task done - %s", self.current_task.uid)
-        except (Exception, TimeoutException):
+        except (Exception, TaskTimeoutError):
             exc_info = sys.exc_info()
             exception_str = traceback.format_exception(*exc_info)
 

--- a/karton/core/karton.py
+++ b/karton/core/karton.py
@@ -437,7 +437,7 @@ class Karton(Consumer, Producer):
         self._send_signaling_status_task("task_begin")
 
     def _send_signaling_status_task_end(
-        self, task: Task, ex: Optional[Exception]
+        self, task: Task, ex: Optional[KartonTaskException]
     ) -> None:
         """Send a begin status signaling task.
 

--- a/karton/core/karton.py
+++ b/karton/core/karton.py
@@ -17,7 +17,6 @@ from .resource import LocalResource
 from .task import Task, TaskState
 from .utils import timeout
 
-KartonTaskException = Union[Exception, BaseException]
 
 
 class Producer(KartonBase):
@@ -134,7 +133,7 @@ class Consumer(KartonServiceBase):
         self._post_hooks: List[
             Tuple[
                 Optional[str],
-                Callable[[Task, Optional[KartonTaskException]], None],
+                Callable[[Task, Optional[BaseException]], None],
             ]
         ] = []
 
@@ -266,7 +265,7 @@ class Consumer(KartonServiceBase):
 
     def add_post_hook(
         self,
-        callback: Callable[[Task, Optional[KartonTaskException]], None],
+        callback: Callable[[Task, Optional[BaseException]], None],
         name: Optional[str] = None,
     ) -> None:
         """
@@ -295,7 +294,7 @@ class Consumer(KartonServiceBase):
                 else:
                     self.log.exception("Pre-hook failed")
 
-    def _run_post_hooks(self, exception: Optional[KartonTaskException]) -> None:
+    def _run_post_hooks(self, exception: Optional[BaseException]) -> None:
         """
         Run registered postprocessing hooks
 
@@ -437,7 +436,7 @@ class Karton(Consumer, Producer):
         self._send_signaling_status_task("task_begin")
 
     def _send_signaling_status_task_end(
-        self, task: Task, ex: Optional[KartonTaskException]
+        self, task: Task, ex: Optional[BaseException]
     ) -> None:
         """Send a begin status signaling task.
 

--- a/karton/core/karton.py
+++ b/karton/core/karton.py
@@ -6,7 +6,7 @@ import argparse
 import sys
 import time
 import traceback
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast
+from typing import Any, Callable, Dict, List, Optional, Tuple, cast
 
 from .__version__ import __version__
 from .backend import KartonBackend, KartonBind, KartonMetrics

--- a/karton/core/karton.py
+++ b/karton/core/karton.py
@@ -130,7 +130,10 @@ class Consumer(KartonServiceBase):
         self.current_task: Optional[Task] = None
         self._pre_hooks: List[Tuple[Optional[str], Callable[[Task], None]]] = []
         self._post_hooks: List[
-            Tuple[Optional[str], Callable[[Task, Optional[Exception]], None]]
+            Tuple[
+                Optional[str],
+                Callable[[Task, Optional[Union[Exception, BaseException]]], None],
+            ]
         ] = []
 
     @abc.abstractmethod

--- a/karton/core/karton.py
+++ b/karton/core/karton.py
@@ -6,7 +6,7 @@ import argparse
 import sys
 import time
 import traceback
-from typing import Any, Callable, Dict, List, Optional, Tuple, cast
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast
 
 from .__version__ import __version__
 from .backend import KartonBackend, KartonBind, KartonMetrics
@@ -290,7 +290,9 @@ class Consumer(KartonServiceBase):
                 else:
                     self.log.exception("Pre-hook failed")
 
-    def _run_post_hooks(self, exception: Optional[Exception]) -> None:
+    def _run_post_hooks(
+        self, exception: Optional[Union[Exception, BaseException]]
+    ) -> None:
         """
         Run registered postprocessing hooks
 


### PR DESCRIPTION
#241 changed the base type of `TaskTimeoutError` from `Exception` to `BaseException`. This caused the exception handlers on https://github.com/CERT-Polska/karton/blob/master/karton/core/karton.py#L182 and https://github.com/CERT-Polska/karton/blob/master/karton/core/karton.py#L189 to not catch the timeout and crash the karton service alltogether.

Minimal test case:

```python
from karton.core import Consumer, Task
from time import sleep

class TimeoutTest(Consumer):
    identity = "karton.timeout-test"
    filters = [{}]

    def __init__(self, *args, **kwargs) -> None:
        super().__init__(*args, **kwargs)
        self.task_timeout = 5

    def process(self, task: Task) -> None:
        print(task.headers)
        sleep(6)


if __name__ == "__main__":
    TimeoutTest.main()
```

pre-patch:
```
[2024-03-25 13:44:02,642][INFO] Received new task - 066f5c91-5e51-4998-8043-8e62656f329f
{'kind': 'raw', 'origin': 'karton.mwdb', 'quality': 'high', 'receiver': 'karton.timeout-test', 'share_3rd_party': True, 'type': 'sample'}
Traceback (most recent call last):
  File "/home/michal/work/karton-playground/timeout_test.py", line 18, in <module>
    TimeoutTest.main()
  File "/home/michal/work/karton-playground/venv/lib/python3.10/site-packages/karton/core/utils.py", line 133, in newfunc
    return self.func(owner, *args, **kwargs)
  File "/home/michal/work/karton-playground/venv/lib/python3.10/site-packages/karton/core/base.py", line 257, in main
    service.loop()
  File "/home/michal/work/karton-playground/venv/lib/python3.10/site-packages/karton/core/karton.py", line 339, in loop
    self.internal_process(task)
  File "/home/michal/work/karton-playground/venv/lib/python3.10/site-packages/karton/core/karton.py", line 179, in internal_process
    self.process(self.current_task)
  File "/home/michal/work/karton-playground/timeout_test.py", line 14, in process
    sleep(6)
  File "/home/michal/work/karton-playground/venv/lib/python3.10/site-packages/karton/core/utils.py", line 78, in throw_timeout
    raise TaskTimeoutError
karton.core.exceptions.TaskTimeoutError
<system exit>
```

post-patch:
```
[2024-03-25 13:43:37,603][INFO] Received new task - 98a5bdcd-2d25-4a20-9946-8f00eff96943
{'kind': 'raw', 'origin': 'karton.mwdb', 'quality': 'high', 'receiver': 'karton.timeout-test', 'share_3rd_party': True, 'type': 'sample'}
[2024-03-25 13:43:42,606][ERROR] Failed to process task - 98a5bdcd-2d25-4a20-9946-8f00eff96943
Traceback (most recent call last):
  File "/home/michal/work/karton-playground/venv/lib/python3.10/site-packages/karton/core/karton.py", line 180, in internal_process
    self.process(self.current_task)
  File "/home/michal/work/karton-playground/timeout_test.py", line 14, in process
    sleep(6)
  File "/home/michal/work/karton-playground/venv/lib/python3.10/site-packages/karton/core/utils.py", line 78, in throw_timeout
    raise TaskTimeoutError
karton.core.exceptions.TaskTimeoutError
[2024-03-25 13:43:42,609][INFO] Received new task - 18d39b77-391c-4c37-b39d-068a46322a8f
```