### PR TITLE
Fix: simplify task deserialization code, don't deserialize resources when orjson fails

### DIFF
--- a/karton/core/backend.py
+++ b/karton/core/backend.py
@@ -449,9 +449,7 @@ class KartonBackend:
             chunk_size,
         )
         return [
-            Task.unserialize(task_data, backend=self)
-            if parse_resources
-            else Task.unserialize(task_data, parse_resources=False)
+            Task.unserialize(task_data, parse_resources=parse_resources)
             for chunk in keys
             for task_data in self.redis.mget(chunk)
             if task_data is not None
@@ -465,9 +463,7 @@ class KartonBackend:
     ) -> Iterator[Task]:
         for chunk in chunks_iter(task_keys, chunk_size):
             yield from (
-                Task.unserialize(task_data, backend=self)
-                if parse_resources
-                else Task.unserialize(task_data, parse_resources=False)
+                Task.unserialize(task_data, parse_resources=parse_resources)
                 for task_data in self.redis.mget(chunk)
                 if task_data is not None
             )

--- a/karton/core/backend.py
+++ b/karton/core/backend.py
@@ -449,7 +449,7 @@ class KartonBackend:
             chunk_size,
         )
         return [
-            Task.unserialize(task_data, parse_resources=parse_resources)
+            Task.unserialize(task_data, backend=self, parse_resources=parse_resources)
             for chunk in keys
             for task_data in self.redis.mget(chunk)
             if task_data is not None
@@ -463,7 +463,9 @@ class KartonBackend:
     ) -> Iterator[Task]:
         for chunk in chunks_iter(task_keys, chunk_size):
             yield from (
-                Task.unserialize(task_data, parse_resources=parse_resources)
+                Task.unserialize(
+                    task_data, backend=self, parse_resources=parse_resources
+                )
                 for task_data in self.redis.mget(chunk)
                 if task_data is not None
             )

--- a/karton/core/task.py
+++ b/karton/core/task.py
@@ -455,11 +455,7 @@ class Task(object):
         if parse_resources:
             task_data = json.loads(data, object_hook=unserialize_resources)
         else:
-            try:
-                task_data = orjson.loads(data)
-            except orjson.JSONDecodeError:
-                # fallback, in case orjson raises exception during loading
-                task_data = json.loads(data)
+            task_data = orjson.loads(data)
 
         # Compatibility with Karton <5.2.0
         headers_persistent_fallback = task_data["payload_persistent"].get(

--- a/karton/core/task.py
+++ b/karton/core/task.py
@@ -459,7 +459,7 @@ class Task(object):
                 task_data = orjson.loads(data)
             except orjson.JSONDecodeError:
                 # fallback, in case orjson raises exception during loading
-                task_data = json.loads(data, object_hook=unserialize_resources)
+                task_data = json.loads(data)
 
         # Compatibility with Karton <5.2.0
         headers_persistent_fallback = task_data["payload_persistent"].get(


### PR DESCRIPTION
- It's not necessary to exclude `backend` (value is always valid, in case of `parse_resources=False` it's just unused)
- Don't fallback from `parse_resources=False` to `parse_resource=True` equivalent when orjson fails to deserialize JSON

Edit: after discussion, we removed fallback to json at all