### PR TITLE
Fix regression: missing string coercion for old-style negated filters

### DIFF
--- a/tests/test_task_filters.py
+++ b/tests/test_task_filters.py
@@ -226,6 +226,39 @@ class TestTaskFilters(unittest.TestCase):
         })
         self.assertFalse(task_different_value.matches_filters(filters))
 
+    def test_negated_non_string_headers(self):
+        filters = [
+            {
+                "block": True,
+                "execute": "!False"
+            }
+        ]
+
+        task_non_block = Task(headers={
+            "block": False,
+            "execute": False,
+        })
+        self.assertFalse(task_non_block.matches_filters(filters))
+
+        task_non_block_execute = Task(headers={
+            "block": False,
+            "execute": True,
+        })
+        self.assertFalse(task_non_block_execute.matches_filters(filters))
+
+        task_block_non_execute = Task(headers={
+            "block": True,
+            "execute": False,
+        })
+        self.assertFalse(task_block_non_execute.matches_filters(filters))
+
+        task_block_execute = Task(headers={
+            "block": True,
+            "execute": True,
+        })
+        self.assertTrue(task_block_execute.matches_filters(filters))
+
+
     def test_negated_filter_for_different_type(self):
         filters = [
             {


### PR DESCRIPTION
v5.5.0 introduced regression for negated boolean old-style filters. Because negation was done by adding "!", filter matching function was doing an implicit header value conversion to string.

This behavior was unintentionally changed by v5.5.0 as new-style (Mongo-style) filters don't perform any type coercions. 

One of the affected components by this regression is Drakvuf Sandbox that uses `{"execute": "!False"}` to filter out all samples that should not be executed. These samples are marked with `{"execute": False}` header, so conversion to string in this case is expected.
