### PR TITLE
Allow to override task timeout for consumer class

### DIFF
--- a/karton/core/karton.py
+++ b/karton/core/karton.py
@@ -328,7 +328,7 @@ class Consumer(KartonServiceBase):
         """
         self.log.info("Service %s started", self.identity)
 
-        if self.task_timeout is not None:
+        if self.task_timeout:
             self.log.info(f"Task timeout is set to {self.task_timeout} seconds")
 
         # Get the old binds and set the new ones atomically

--- a/karton/core/karton.py
+++ b/karton/core/karton.py
@@ -106,11 +106,13 @@ class Consumer(KartonServiceBase):
     :param config: Karton config to use for service configuration
     :param identity: Karton service identity
     :param backend: Karton backend to use
+    :param task_timeout: The maximum time, in seconds, this consumer will wait for a task to finish processing before being CRASHED on timeout
     """
 
     filters: List[Dict[str, Any]] = []
     persistent: bool = True
     version: Optional[str] = None
+    task_timeout = None
 
     def __init__(
         self,
@@ -130,7 +132,7 @@ class Consumer(KartonServiceBase):
             self.config.getboolean("karton", "persistent", self.persistent)
             and not self.debug
         )
-        self.task_timeout = self.config.getint("karton", "task_timeout")
+        self.task_timeout = self.task_timeout or self.config.getint("karton", "task_timeout")
         self.current_task: Optional[Task] = None
         self._pre_hooks: List[Tuple[Optional[str], Callable[[Task], None]]] = []
         self._post_hooks: List[

--- a/karton/core/karton.py
+++ b/karton/core/karton.py
@@ -106,7 +106,7 @@ class Consumer(KartonServiceBase):
     :param config: Karton config to use for service configuration
     :param identity: Karton service identity
     :param backend: Karton backend to use
-    :param task_timeout: The maximum time, in seconds, this consumer will wait for a task to finish processing before being CRASHED on timeout
+    :param task_timeout: The maximum time, in seconds, this consumer will wait for a task to finish processing before being CRASHED on timeout. Set 0 for unlimited, and None for using global value
     """
 
     filters: List[Dict[str, Any]] = []
@@ -132,7 +132,8 @@ class Consumer(KartonServiceBase):
             self.config.getboolean("karton", "persistent", self.persistent)
             and not self.debug
         )
-        self.task_timeout = self.task_timeout or self.config.getint("karton", "task_timeout")
+        if self.task_timeout is None:
+            self.task_timeout = self.config.getint("karton", "task_timeout")
         self.current_task: Optional[Task] = None
         self._pre_hooks: List[Tuple[Optional[str], Callable[[Task], None]]] = []
         self._post_hooks: List[

--- a/karton/core/karton.py
+++ b/karton/core/karton.py
@@ -106,7 +106,9 @@ class Consumer(KartonServiceBase):
     :param config: Karton config to use for service configuration
     :param identity: Karton service identity
     :param backend: Karton backend to use
-    :param task_timeout: The maximum time, in seconds, this consumer will wait for a task to finish processing before being CRASHED on timeout. Set 0 for unlimited, and None for using global value
+    :param task_timeout: The maximum time, in seconds, this consumer will wait for
+                         a task to finish processing before being CRASHED on timeout.
+                         Set 0 for unlimited, and None for using global value
     """
 
     filters: List[Dict[str, Any]] = []


### PR DESCRIPTION
Hello!

While examining your `karton-core` code, I found karton.task_timeout config parameter (it also described in docs).

Sometimes it could hard to use united timeout for services (for example, you expect 'karton-yara' to work at most 30 sec, and 'karton-drakvuf' at most 10 mins), so it's preferable to allow custom settings for each Consumer.

This PR introduces Consumer.task_timeout that this behaviour:
- `None` - use global value described in config file.
- `0` - disable global-set task timeout.
- positive integer - kill task on timeout.