### PR TITLE
Pin boto3<1.36.0 because 1.36 introduces breaking changes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 redis
-boto3
 orjson
+# https://github.com/boto/boto3/issues/4392
+boto3<1.36.0


### PR DESCRIPTION
boto3 1.36.0 introduces incompatible changes with non-AWS S3 providers related with integrity checksums: https://github.com/boto/boto3/issues/4392

In our case, it resulted in MissingContentMD5 error thrown by MinIO on DeleteObjects call #269 because boto3 1.36.0 completely removes `Content-MD5` evaluation and that's a required header by our MinIO version. Evaluation removal was done here: https://github.com/boto/botocore/commit/590103bde8c18174afb9d17970c7e3d2520ca25a#diff-6430b10ddffa7de73a08acc48a810a748dc2b01197c28fc974699d3d1fe9e4ffL1362

MinIO adds support for new integrity checksums in fresh release:
- [RELEASE.2025-01-20T14-49-07Z](https://github.com/minio/minio/releases/tag/RELEASE.2025-01-20T14-49-07Z)
- https://github.com/minio/minio/pull/20855

but as we don't explicitly require a specific S3 provider and boto3 has still compatibility issues with non-AWS ones, it's much more safe to pin to the previous version for a while and wait until issues are resolved.

closes #269 