### PR TITLE
Add optional log publishing + task tracking settings

### DIFF
--- a/karton/core/backend.py
+++ b/karton/core/backend.py
@@ -1070,17 +1070,20 @@ class KartonBackend:
                 raise e
         return False
 
-    def log_identity_output(self, identity: str, headers: Dict[str, Any]) -> None:
+    def log_identity_output(
+        self, identity: str, headers: Dict[str, Any], task_tracking_ttl: int
+    ) -> None:
         """
         Store the type of task outputted for given producer to
         be used in tracking karton service connections.
 
         :param identity: producer identity
         :param headers: outputted headers
+        :param task_tracking_ttl: expire time (in seconds)
         """
 
         self.redis.sadd(f"{KARTON_OUTPUTS_NAMESPACE}:{identity}", json.dumps(headers))
-        self.redis.expire(f"{KARTON_OUTPUTS_NAMESPACE}:{identity}", 60 * 60 * 24 * 30)
+        self.redis.expire(f"{KARTON_OUTPUTS_NAMESPACE}:{identity}", task_tracking_ttl)
 
     def get_outputs(self) -> List[KartonOutputs]:
         """

--- a/karton/core/base.py
+++ b/karton/core/base.py
@@ -36,6 +36,9 @@ class KartonBase(abc.ABC):
         backend: Optional[KartonBackend] = None,
     ) -> None:
         self.config = config or Config()
+        self.enable_publish_log = self.config.getboolean(
+            "logging", "enable_publish", True
+        )
 
         # If not passed via constructor - get it from class
         if identity is not None:
@@ -63,7 +66,9 @@ class KartonBase(abc.ABC):
         )
 
         self._log_handler = KartonLogHandler(
-            backend=self.backend, channel=self.identity
+            backend=self.backend,
+            channel=self.identity,
+            enable_publish_log=self.enable_publish_log,
         )
         self.current_task: Optional[Task] = None
 

--- a/karton/core/base.py
+++ b/karton/core/base.py
@@ -66,9 +66,7 @@ class KartonBase(abc.ABC):
         )
 
         self._log_handler = KartonLogHandler(
-            backend=self.backend,
-            channel=self.identity,
-            enable_publish_log=self.enable_publish_log,
+            backend=self.backend, channel=self.identity
         )
         self.current_task: Optional[Task] = None
 
@@ -113,7 +111,7 @@ class KartonBase(abc.ABC):
         )
         logger.addHandler(stream_handler)
 
-        if not self.debug:
+        if not self.debug and self.enable_publish_log:
             logger.addHandler(self._log_handler)
 
     @property

--- a/karton/core/logger.py
+++ b/karton/core/logger.py
@@ -15,22 +15,17 @@ class KartonLogHandler(logging.Handler):
     logging.Handler that passes logs to the Karton backend.
     """
 
-    def __init__(
-        self, backend: KartonBackend, channel: str, enable_publish_log: bool = True
-    ) -> None:
+    def __init__(self, backend: KartonBackend, channel: str) -> None:
         logging.Handler.__init__(self)
         self.backend = backend
         self.task: Optional[Task] = None
         self.is_consumer_active: bool = True
         self.channel: str = channel
-        self.enable_publish_log: bool = enable_publish_log
 
     def set_task(self, task: Task) -> None:
         self.task = task
 
     def emit(self, record: logging.LogRecord) -> None:
-        if not self.enable_publish_log:
-            return None
         ignore_fields = [
             "args",
             "asctime",

--- a/karton/core/logger.py
+++ b/karton/core/logger.py
@@ -15,17 +15,22 @@ class KartonLogHandler(logging.Handler):
     logging.Handler that passes logs to the Karton backend.
     """
 
-    def __init__(self, backend: KartonBackend, channel: str) -> None:
+    def __init__(
+        self, backend: KartonBackend, channel: str, enable_publish_log: bool = True
+    ) -> None:
         logging.Handler.__init__(self)
         self.backend = backend
         self.task: Optional[Task] = None
         self.is_consumer_active: bool = True
         self.channel: str = channel
+        self.enable_publish_log: bool = enable_publish_log
 
     def set_task(self, task: Task) -> None:
         self.task = task
 
     def emit(self, record: logging.LogRecord) -> None:
+        if not self.enable_publish_log:
+            return None
         ignore_fields = [
             "args",
             "asctime",

--- a/karton/system/system.py
+++ b/karton/system/system.py
@@ -31,7 +31,7 @@ class SystemService(KartonServiceBase):
     TASK_DISPATCHED_TIMEOUT = 24 * 3600
     TASK_STARTED_TIMEOUT = 24 * 3600
     TASK_CRASHED_TIMEOUT = 3 * 24 * 3600
-    TASK_TRACKING_TTL = 60 * 60 * 24 * 30
+    TASK_TRACKING_TTL = 30 * 24 * 3600
 
     def __init__(self, config: Optional[Config]) -> None:
         super().__init__(config=config)


### PR DESCRIPTION
- Added a flag to enable/disable log publishing to Redis
- Added a flag to enable/disable the task tracking on Redis
- Added settings to specify Redis TTL for the task tracking info

It would be nice to provide the settings to give the freedom to the end user to decide whether to enable or disable logs publishing to Redis and the task tracking feature.