### PR TITLE
Feature: asyncio support

### DIFF
--- a/karton/core/asyncio/backend.py
+++ b/karton/core/asyncio/backend.py
@@ -1,0 +1,231 @@
+import logging
+from typing import IO, Optional, Union
+
+import aioboto3
+from aiobotocore.credentials import ContainerProvider, InstanceMetadataProvider
+from aiobotocore.session import ClientCreatorContext, get_session
+from aiobotocore.utils import InstanceMetadataFetcher
+from redis.asyncio import Redis
+from redis.asyncio.client import Pipeline
+from redis.exceptions import AuthenticationError
+
+from karton.core import Config, Task
+from karton.core.backend import (
+    KARTON_TASK_NAMESPACE,
+    KARTON_TASKS_QUEUE,
+    KartonBackendBase,
+    KartonMetrics,
+    KartonServiceInfo,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class KartonAsyncBackend(KartonBackendBase):
+    def __init__(
+        self,
+        config: Config,
+        identity: Optional[str] = None,
+        service_info: Optional[KartonServiceInfo] = None,
+    ) -> None:
+        super().__init__(config, identity, service_info)
+        self._redis: Optional[Redis] = None
+        self._s3: Optional[ClientCreatorContext] = None
+
+    @property
+    def redis(self) -> Redis:
+        if not self._redis:
+            raise RuntimeError("Call connect() first before using KartonAsyncBackend")
+        return self._redis
+
+    @property
+    def s3(self) -> ClientCreatorContext:
+        if not self._s3:
+            raise RuntimeError("Call connect() first before using KartonAsyncBackend")
+        return self._s3
+
+    async def connect(self):
+        self._redis = await self.make_redis(
+            self.config, identity=self.identity, service_info=self.service_info
+        )
+
+        endpoint = self.config.get("s3", "address")
+        access_key = self.config.get("s3", "access_key")
+        secret_key = self.config.get("s3", "secret_key")
+        iam_auth = self.config.getboolean("s3", "iam_auth")
+
+        if not endpoint:
+            raise RuntimeError("Attempting to get S3 client without an endpoint set")
+
+        if access_key and secret_key and iam_auth:
+            logger.warning(
+                "Warning: iam is turned on and both S3 access key and secret key are"
+                " provided"
+            )
+
+        if iam_auth:
+            s3_client_creator = await self.iam_auth_s3(endpoint)
+            if s3_client_creator:
+                self._s3 = s3_client_creator
+                return
+
+        if access_key is None or secret_key is None:
+            raise RuntimeError(
+                "Attempting to get S3 client without an access_key/secret_key set"
+            )
+
+        session = aioboto3.Session()
+        self._s3 = session.client(
+            "s3",
+            endpoint_url=endpoint,
+            aws_access_key_id=access_key,
+            aws_secret_access_key=secret_key,
+        )
+
+    async def iam_auth_s3(self, endpoint: str):
+        boto_session = get_session()
+        iam_providers = [
+            ContainerProvider(),
+            InstanceMetadataProvider(
+                iam_role_fetcher=InstanceMetadataFetcher(timeout=1000, num_attempts=2)
+            ),
+        ]
+
+        for provider in iam_providers:
+            creds = await provider.load()
+            if creds:
+                boto_session._credentials = creds  # type: ignore
+                return aioboto3.Session(botocore_session=boto_session).client(
+                    "s3",
+                    endpoint_url=endpoint,
+                )
+
+    @staticmethod
+    async def make_redis(
+        config,
+        identity: Optional[str] = None,
+        service_info: Optional[KartonServiceInfo] = None,
+    ) -> Redis:
+        """
+        Create and test a Redis connection.
+
+        :param config: The karton configuration
+        :param identity: Karton service identity
+        :param service_info: Additional service identity metadata
+        :return: Redis connection
+        """
+        if service_info is not None:
+            client_name: Optional[str] = service_info.make_client_name()
+        else:
+            client_name = identity
+
+        redis_args = {
+            "host": config["redis"]["host"],
+            "port": config.getint("redis", "port", 6379),
+            "db": config.getint("redis", "db", 0),
+            "username": config.get("redis", "username"),
+            "password": config.get("redis", "password"),
+            "client_name": client_name,
+            # set socket_timeout to None if set to 0
+            "socket_timeout": config.getint("redis", "socket_timeout", 30) or None,
+            "decode_responses": True,
+        }
+        try:
+            rs = Redis(**redis_args)
+            await rs.ping()
+        except AuthenticationError:
+            # Maybe we've sent a wrong password.
+            # Or maybe the server is not (yet) password protected
+            # To make smooth transition possible, try to login insecurely
+            del redis_args["password"]
+            rs = Redis(**redis_args)
+            await rs.ping()
+        return rs
+
+    async def register_task(self, task: Task, pipe: Optional[Pipeline] = None) -> None:
+        """
+        Register or update task in Redis.
+
+        :param task: Task object
+        :param pipe: Optional pipeline object if operation is a part of pipeline
+        """
+        rs = pipe or self.redis
+        await rs.set(f"{KARTON_TASK_NAMESPACE}:{task.uid}", task.serialize())
+
+    async def produce_unrouted_task(self, task: Task) -> None:
+        """
+        Add given task to unrouted task (``karton.tasks``) queue
+
+        Task must be registered before with :py:meth:`register_task`
+
+        :param task: Task object
+        """
+        await self.redis.rpush(KARTON_TASKS_QUEUE, task.uid)
+
+    async def increment_metrics(
+        self, metric: KartonMetrics, identity: str, pipe: Optional[Pipeline] = None
+    ) -> None:
+        """
+        Increments metrics for given operation type and identity
+
+        :param metric: Operation metric type
+        :param identity: Related Karton service identity
+        :param pipe: Optional pipeline object if operation is a part of pipeline
+        """
+        rs = pipe or self.redis
+        await rs.hincrby(metric.value, identity, 1)
+
+    async def upload_object(
+        self,
+        bucket: str,
+        object_uid: str,
+        content: Union[bytes, IO[bytes]],
+    ) -> None:
+        """
+        Upload resource object to underlying object storage (S3)
+
+        :param bucket: Bucket name
+        :param object_uid: Object identifier
+        :param content: Object content as bytes or file-like stream
+        """
+        async with self.s3 as client:
+            await client.put_object(Bucket=bucket, Key=object_uid, Body=content)
+
+    async def upload_object_from_file(
+        self, bucket: str, object_uid: str, path: str
+    ) -> None:
+        """
+        Upload resource object file to underlying object storage
+
+        :param bucket: Bucket name
+        :param object_uid: Object identifier
+        :param path: Path to the object content
+        """
+        async with self.s3 as client:
+            with open(path, "rb") as f:
+                await client.put_object(Bucket=bucket, Key=object_uid, Body=f)
+
+    async def download_object(self, bucket: str, object_uid: str) -> bytes:
+        """
+        Download resource object from object storage.
+
+        :param bucket: Bucket name
+        :param object_uid: Object identifier
+        :return: Content bytes
+        """
+        async with self.s3 as client:
+            obj = await client.get_object(Bucket=bucket, Key=object_uid)
+            return await obj["Body"].read()
+
+    async def download_object_to_file(
+        self, bucket: str, object_uid: str, path: str
+    ) -> None:
+        """
+        Download resource object from object storage to file
+
+        :param bucket: Bucket name
+        :param object_uid: Object identifier
+        :param path: Target file path
+        """
+        async with self.s3 as client:
+            await client.download_file(Bucket=bucket, Key=object_uid, Filename=path)

--- a/karton/core/asyncio/base.py
+++ b/karton/core/asyncio/base.py
@@ -1,0 +1,119 @@
+import abc
+import asyncio
+from contextlib import contextmanager
+from typing import Optional
+
+from karton.core import Task
+from karton.core.__version__ import __version__
+from karton.core.backend import KartonServiceInfo
+from karton.core.base import ConfigMixin, LoggingMixin
+from karton.core.config import Config
+from karton.core.exceptions import HardShutdownInterrupt
+from karton.core.task import get_current_task, set_current_task
+from karton.core.utils import StrictClassMethod, graceful_killer
+
+from .backend import KartonAsyncBackend
+from .logger import KartonAsyncLogHandler
+
+
+class KartonAsyncBase(abc.ABC, ConfigMixin, LoggingMixin):
+    """
+    Base class for all Karton services
+
+    You can set an informative version information by setting the ``version`` class
+    attribute.
+    """
+
+    #: Karton service identity
+    identity: str = ""
+    #: Karton service version
+    version: Optional[str] = None
+    #: Include extended service information for non-consumer services
+    with_service_info: bool = False
+
+    def __init__(
+        self,
+        config: Optional[Config] = None,
+        identity: Optional[str] = None,
+        backend: Optional[KartonAsyncBackend] = None,
+    ) -> None:
+        ConfigMixin.__init__(self, config, identity)
+
+        self.service_info = None
+        if self.identity is not None and self.with_service_info:
+            self.service_info = KartonServiceInfo(
+                identity=self.identity,
+                karton_version=__version__,
+                service_version=self.version,
+            )
+
+        self.backend = backend or KartonAsyncBackend(
+            self.config, identity=self.identity, service_info=self.service_info
+        )
+
+        log_handler = KartonAsyncLogHandler(backend=self.backend, channel=self.identity)
+        LoggingMixin.__init__(self, log_handler)
+
+    @property
+    def current_task(self) -> Optional[Task]:
+        return get_current_task()
+
+    @current_task.setter
+    def current_task(self, task: Optional[Task]):
+        set_current_task(task)
+
+
+class KartonServiceBase(KartonAsyncBase):
+    """
+    Karton base class for looping services.
+
+    You can set an informative version information by setting the ``version`` class
+    attribute
+
+    :param config: Karton config to use for service configuration
+    :param identity: Karton service identity to use
+    :param backend: Karton backend to use
+    """
+
+    def __init__(
+        self,
+        config: Optional[Config] = None,
+        identity: Optional[str] = None,
+        backend: Optional[KartonAsyncBackend] = None,
+    ) -> None:
+        super().__init__(
+            config=config,
+            identity=identity,
+            backend=backend,
+        )
+        self.setup_logger()
+        self._shutdown = False
+
+    def _do_shutdown(self) -> None:
+        self.log.info("Got signal, shutting down...")
+        self._shutdown = True
+
+    @property
+    def shutdown(self):
+        return self._shutdown
+
+    @contextmanager
+    def graceful_killer(self):
+        try:
+            with graceful_killer(self._do_shutdown):
+                yield
+        except HardShutdownInterrupt:
+            self.log.info("Hard shutting down!")
+            raise
+
+    # Base class for Karton services
+    @abc.abstractmethod
+    async def loop(self) -> None:
+        # Karton service entrypoint
+        raise NotImplementedError
+
+    @StrictClassMethod
+    def main(cls) -> None:
+        """Main method invoked from CLI."""
+        service = cls.karton_from_args()
+        asyncio.run(service.loop())

--- a/karton/core/asyncio/karton.py
+++ b/karton/core/asyncio/karton.py
@@ -1,0 +1,94 @@
+import time
+from typing import Optional
+
+from karton.core import Config, Task
+from karton.core.resource import LocalResource as SyncLocalResource
+
+from ..backend import KartonMetrics
+from .backend import KartonAsyncBackend
+from .base import KartonAsyncBase
+from .resource import LocalResource
+
+
+class Producer(KartonAsyncBase):
+    """
+    Producer part of Karton. Used for dispatching initial tasks into karton.
+
+    :param config: Karton configuration object (optional)
+    :type config: :class:`karton.Config`
+    :param identity: Producer name (optional)
+    :type identity: str
+
+    Usage example:
+
+    .. code-block:: python
+
+        from karton.core import Producer
+
+        producer = Producer(identity="karton.mwdb")
+        task = Task(
+            headers={
+                "type": "sample",
+                "kind": "raw"
+            },
+            payload={
+                "sample": Resource("sample.exe", b"put content here")
+            }
+        )
+        producer.send_task(task)
+
+    :param config: Karton config to use for service configuration
+    :param identity: Karton producer identity
+    :param backend: Karton backend to use
+    """
+
+    def __init__(
+        self,
+        config: Optional[Config] = None,
+        identity: Optional[str] = None,
+        backend: Optional[KartonAsyncBackend] = None,
+    ) -> None:
+        super().__init__(config=config, identity=identity, backend=backend)
+
+    async def send_task(self, task: Task) -> bool:
+        """
+        Sends a task to the unrouted task queue. Takes care of logging.
+        Given task will be child of task we are currently handling (if such exists).
+
+        :param task: Task object to be sent
+        :return: Bool indicating if the task was delivered
+        """
+        self.log.debug("Dispatched task %s", task.uid)
+
+        # Complete information about task
+        if self.current_task is not None:
+            task.set_task_parent(self.current_task)
+            task.merge_persistent_payload(self.current_task)
+            task.merge_persistent_headers(self.current_task)
+            task.priority = self.current_task.priority
+
+        task.last_update = time.time()
+        task.headers.update({"origin": self.identity})
+
+        # Ensure all local resources have good buckets
+        for resource in task.iterate_resources():
+            if isinstance(resource, LocalResource) and not resource.bucket:
+                resource.bucket = self.backend.default_bucket_name
+            if isinstance(resource, SyncLocalResource):
+                raise RuntimeError(
+                    "Synchronous resources are not supported. "
+                    "Use karton.core.asyncio.resource module instead."
+                )
+
+        # Register new task
+        await self.backend.register_task(task)
+
+        # Upload local resources
+        for resource in task.iterate_resources():
+            if isinstance(resource, LocalResource):
+                await resource.upload(self.backend)
+
+        # Add task to karton.tasks
+        await self.backend.produce_unrouted_task(task)
+        await self.backend.increment_metrics(KartonMetrics.TASK_PRODUCED, self.identity)
+        return True

--- a/karton/core/asyncio/logger.py
+++ b/karton/core/asyncio/logger.py
@@ -1,0 +1,20 @@
+import logging
+import platform
+
+from .backend import KartonAsyncBackend
+
+HOSTNAME = platform.node()
+
+
+class KartonAsyncLogHandler(logging.Handler):
+    """
+    logging.Handler that passes logs to the Karton backend.
+    """
+
+    def __init__(self, backend: KartonAsyncBackend, channel: str) -> None:
+        logging.Handler.__init__(self)
+        self.backend = backend
+        self.is_consumer_active: bool = True
+        self.channel: str = channel
+
+    def emit(self, record: logging.LogRecord) -> None: ...

--- a/karton/core/asyncio/resource.py
+++ b/karton/core/asyncio/resource.py
@@ -1,0 +1,371 @@
+import contextlib
+import os
+import shutil
+import tempfile
+import zipfile
+from io import BytesIO
+from typing import IO, TYPE_CHECKING, Any, AsyncIterator, Dict, List, Optional, Union
+
+from karton.core.resource import LocalResourceBase, ResourceBase
+
+if TYPE_CHECKING:
+    from .backend import KartonAsyncBackend
+
+
+class LocalResource(LocalResourceBase):
+    """
+    Represents local resource with arbitrary binary data e.g. file contents.
+
+    Local resources will be uploaded to object hub (S3) during
+    task dispatching.
+
+    .. code-block:: python
+
+        # Creating resource from bytes
+        sample = Resource("original_name.exe", content=b"X5O!P%@AP[4\\
+        PZX54(P^)7CC)7}$EICAR-STANDARD-ANT...")
+
+        # Creating resource from path
+        sample = Resource("original_name.exe", path="sample/original_name.exe")
+
+    :param name: Name of the resource (e.g. name of file)
+    :param content: Resource content
+    :param path: Path of file with resource content
+    :param bucket: Alternative S3 bucket for resource
+    :param metadata: Resource metadata
+    :param uid: Alternative S3 resource id
+    :param sha256: Resource sha256 hash
+    :param fd: Seekable file descriptor
+    :param _flags: Resource flags
+    :param _close_fd: Close file descriptor after upload (default: False)
+    """
+
+    def __init__(
+        self,
+        name: str,
+        content: Optional[Union[str, bytes]] = None,
+        path: Optional[str] = None,
+        bucket: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        uid: Optional[str] = None,
+        sha256: Optional[str] = None,
+        fd: Optional[IO[bytes]] = None,
+        _flags: Optional[List[str]] = None,
+        _close_fd: bool = False,
+    ) -> None:
+        super().__init__(
+            name=name,
+            content=content,
+            path=path,
+            bucket=bucket,
+            metadata=metadata,
+            uid=uid,
+            sha256=sha256,
+            fd=fd,
+            _flags=_flags,
+            _close_fd=_close_fd,
+        )
+
+    async def _upload(self, backend: "KartonAsyncBackend") -> None:
+        """Internal function for uploading resources
+
+        :param backend: KartonBackend to use while uploading the resource
+
+        :meta private:
+        """
+
+        # Note: never transform resource into Remote
+        # Multiple task dispatching with same local, in that case resource
+        # can be deleted between tasks.
+        if self.bucket is None:
+            raise RuntimeError(
+                "Resource object can't be uploaded because its bucket is not set"
+            )
+
+        if self._content:
+            # Upload contents
+            await backend.upload_object(self.bucket, self.uid, self._content)
+        elif self.fd:
+            if self.fd.tell() != 0:
+                raise RuntimeError(
+                    f"Resource object can't be uploaded: "
+                    f"file descriptor must point at first byte "
+                    f"(fd.tell = {self.fd.tell()})"
+                )
+            # Upload contents from fd
+            await backend.upload_object(self.bucket, self.uid, self.fd)
+            # If file descriptor is managed by Resource, close it after upload
+            if self._close_fd:
+                self.fd.close()
+        elif self._path:
+            # Upload file provided by path
+            await backend.upload_object_from_file(self.bucket, self.uid, self._path)
+
+    async def upload(self, backend: "KartonAsyncBackend") -> None:
+        """Internal function for uploading resources
+
+        :param backend: KartonBackend to use while uploading the resource
+
+        :meta private:
+        """
+        if not self._content and not self._path and not self.fd:
+            raise RuntimeError("Can't upload resource without content")
+        await self._upload(backend)
+
+
+Resource = LocalResource
+
+
+class RemoteResource(ResourceBase):
+    """
+    Keeps reference to remote resource object shared between subsystems
+    via object storage (S3)
+
+    Should never be instantiated directly by subsystem, but can be directly passed to
+    outgoing payload.
+
+    :param name: Name of the resource (e.g. name of file)
+    :param bucket: Alternative S3 bucket for resource
+    :param metadata: Resource metadata
+    :param uid: Alternative S3 resource id
+    :param size: Resource size
+    :param backend: :py:meth:`KartonBackend` to bind to this resource
+    :param sha256: Resource sha256 hash
+    :param _flags: Resource flags
+    """
+
+    def __init__(
+        self,
+        name: str,
+        bucket: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        uid: Optional[str] = None,
+        size: Optional[int] = None,
+        backend: Optional["KartonAsyncBackend"] = None,
+        sha256: Optional[str] = None,
+        _flags: Optional[List[str]] = None,
+    ) -> None:
+        super(RemoteResource, self).__init__(
+            name,
+            bucket=bucket,
+            metadata=metadata,
+            sha256=sha256,
+            _uid=uid,
+            _size=size,
+            _flags=_flags,
+        )
+        self.backend = backend
+
+    def loaded(self) -> bool:
+        """
+        Checks whether resource is loaded into memory
+
+        :return: Flag indicating if the resource is loaded or not
+        """
+        return self._content is not None
+
+    @classmethod
+    def from_dict(
+        cls, dict: Dict[str, Any], backend: Optional["KartonAsyncBackend"]
+    ) -> "RemoteResource":
+        """
+        Internal deserialization method for remote resources
+
+        :param dict: Serialized information about resource
+        :param backend: KartonBackend object
+        :return: Deserialized :py:meth:`RemoteResource` object
+
+        :meta private:
+        """
+        # Backwards compatibility
+        metadata = dict.get("metadata", {})
+        if "sha256" in dict:
+            metadata["sha256"] = dict["sha256"]
+
+        return cls(
+            name=dict["name"],
+            metadata=metadata,
+            bucket=dict["bucket"],
+            uid=dict["uid"],
+            size=dict.get("size"),  # Backwards compatibility (2.x.x)
+            backend=backend,
+            _flags=dict.get("flags"),  # Backwards compatibility (3.x.x)
+        )
+
+    def unload(self) -> None:
+        """
+        Unloads resource object from memory
+        """
+        self._content = None
+
+    async def download(self) -> bytes:
+        """
+        Downloads remote resource content from object hub into memory.
+
+        .. code-block:: python
+
+            sample = self.current_task.get_resource("sample")
+
+            # Ensure that resource will be downloaded before it will be
+            # passed to processing method
+            sample.download()
+
+            self.process_sample(sample)
+
+        :return: Downloaded content bytes
+        """
+        if self.backend is None:
+            raise RuntimeError(
+                (
+                    "Resource object can't be downloaded because it's not bound to "
+                    "the backend"
+                )
+            )
+        if self.bucket is None:
+            raise RuntimeError(
+                "Resource object can't be downloaded because its bucket is not set"
+            )
+
+        if self._content is None:
+            self._content = await self.backend.download_object(self.bucket, self.uid)
+        return self._content
+
+    async def download_to_file(self, path: str) -> None:
+        """
+        Downloads remote resource into file.
+
+        .. code-block:: python
+
+            sample = self.current_task.get_resource("sample")
+
+            sample.download_to_file("sample/sample.exe")
+
+            with open("sample/sample.exe", "rb") as f:
+                contents = f.read()
+
+        :param path: Path to download the resource into
+        """
+        if self.backend is None:
+            raise RuntimeError(
+                (
+                    "Resource object can't be downloaded because it's not bound to "
+                    "the backend"
+                )
+            )
+        if self.bucket is None:
+            raise RuntimeError(
+                "Resource object can't be downloaded because its bucket is not set"
+            )
+
+        await self.backend.download_object_to_file(self.bucket, self.uid, path)
+
+    @contextlib.asynccontextmanager
+    async def download_temporary_file(self, suffix=None) -> AsyncIterator[IO[bytes]]:
+        """
+        Downloads remote resource into named temporary file.
+
+        .. code-block:: python
+
+            sample = self.current_task.get_resource("sample")
+
+            with sample.download_temporary_file() as f:
+                contents = f.read()
+                path = f.name
+
+            # Temporary file is deleted after exitting the "with" scope
+
+        :return: ContextManager with the temporary file
+        """
+        # That tempfile-fu is necessary because minio.fget_object removes file
+        # under provided path and renames its own part-file with downloaded content
+        # under previously deleted path
+        # Weird move, but ok...
+        tmp = tempfile.NamedTemporaryFile(delete=False, suffix=suffix)
+        tmp.close()
+        try:
+            await self.download_to_file(tmp.name)
+            with open(tmp.name, "rb") as f:
+                yield f
+        finally:
+            os.remove(tmp.name)
+
+    @contextlib.asynccontextmanager
+    async def zip_file(self) -> AsyncIterator[zipfile.ZipFile]:
+        """
+        If resource contains a Zip file, downloads it to the temporary file
+        and wraps it with ZipFile object.
+
+        .. code-block:: python
+
+            dumps = self.current_task.get_resource("dumps")
+
+            with dumps.zip_file() as zipf:
+                print("Fetched dumps: ", zipf.namelist())
+
+        By default: method downloads zip into temporary file, which is deleted after
+        leaving the context. If you want to load zip into memory,
+        call :py:meth:`RemoteResource.download` first.
+
+        If you want to pre-download Zip under specified path and open it using
+        zipfile module, you need to do this manually:
+
+        .. code-block:: python
+
+            dumps = self.current_task.get_resource("dumps")
+
+            # Download zip file
+            zip_path = "./dumps.zip"
+            dumps.download_to_file(zip_path)
+
+            zipf = zipfile.Zipfile(zip_path)
+
+        :return: ContextManager with zipfile
+        """
+        if self._content:
+            yield zipfile.ZipFile(BytesIO(self._content))
+        else:
+            async with self.download_temporary_file() as f:
+                yield zipfile.ZipFile(f)
+
+    async def extract_to_directory(self, path: str) -> None:
+        """
+        If resource contains a Zip file, extracts files contained in Zip into
+        provided path.
+
+        By default: method downloads zip into temporary file, which is deleted
+        after extraction. If you want to load zip into memory, call
+        :py:meth:`RemoteResource.download` first.
+
+        :param path: Directory path where the resource should be unpacked
+        """
+        async with self.zip_file() as zf:
+            zf.extractall(path)
+
+    @contextlib.asynccontextmanager
+    async def extract_temporary(self) -> AsyncIterator[str]:
+        """
+        If resource contains a Zip file, extracts files contained in Zip
+        to the temporary directory.
+
+        Returns path of directory with extracted files. Directory is recursively
+        deleted after leaving the context.
+
+        .. code-block:: python
+
+            dumps = self.current_task.get_resource("dumps")
+
+            with dumps.extract_temporary() as dumps_path:
+                print("Fetched dumps:", os.listdir(dumps_path))
+
+        By default: method downloads zip into temporary file, which is deleted
+        after extraction. If you want to load zip into memory, call
+        :py:meth:`RemoteResource.download` first.
+
+        :return: ContextManager with the temporary directory
+        """
+        tmpdir = tempfile.mkdtemp()
+        try:
+            await self.extract_to_directory(tmpdir)
+            yield tmpdir
+        finally:
+            shutil.rmtree(tmpdir)

--- a/karton/core/logger.py
+++ b/karton/core/logger.py
@@ -2,10 +2,9 @@ import logging
 import platform
 import traceback
 import warnings
-from typing import Optional
 
 from .backend import KartonBackend
-from .task import Task
+from .task import get_current_task
 
 HOSTNAME = platform.node()
 
@@ -18,12 +17,8 @@ class KartonLogHandler(logging.Handler):
     def __init__(self, backend: KartonBackend, channel: str) -> None:
         logging.Handler.__init__(self)
         self.backend = backend
-        self.task: Optional[Task] = None
         self.is_consumer_active: bool = True
         self.channel: str = channel
-
-    def set_task(self, task: Task) -> None:
-        self.task = task
 
     def emit(self, record: logging.LogRecord) -> None:
         ignore_fields = [
@@ -54,8 +49,9 @@ class KartonLogHandler(logging.Handler):
         log_line["type"] = "log"
         log_line["message"] = self.format(record)
 
-        if self.task is not None:
-            log_line["task"] = self.task.serialize()
+        current_task = get_current_task()
+        if current_task is not None:
+            log_line["task"] = current_task.serialize()
 
         log_line["hostname"] = HOSTNAME
 

--- a/karton/core/resource.py
+++ b/karton/core/resource.py
@@ -150,34 +150,7 @@ class ResourceBase(object):
         }
 
 
-class LocalResource(ResourceBase):
-    """
-    Represents local resource with arbitrary binary data e.g. file contents.
-
-    Local resources will be uploaded to object hub (S3) during
-    task dispatching.
-
-    .. code-block:: python
-
-        # Creating resource from bytes
-        sample = Resource("original_name.exe", content=b"X5O!P%@AP[4\\
-        PZX54(P^)7CC)7}$EICAR-STANDARD-ANT...")
-
-        # Creating resource from path
-        sample = Resource("original_name.exe", path="sample/original_name.exe")
-
-    :param name: Name of the resource (e.g. name of file)
-    :param content: Resource content
-    :param path: Path of file with resource content
-    :param bucket: Alternative S3 bucket for resource
-    :param metadata: Resource metadata
-    :param uid: Alternative S3 resource id
-    :param sha256: Resource sha256 hash
-    :param fd: Seekable file descriptor
-    :param _flags: Resource flags
-    :param _close_fd: Close file descriptor after upload (default: False)
-    """
-
+class LocalResourceBase(ResourceBase):
     def __init__(
         self,
         name: str,
@@ -194,7 +167,7 @@ class LocalResource(ResourceBase):
         if len(list(filter(None, [path, content, fd]))) != 1:
             raise ValueError("You must exclusively provide a path, content or fd")
 
-        super(LocalResource, self).__init__(
+        super().__init__(
             name,
             content=content,
             path=path,
@@ -247,7 +220,7 @@ class LocalResource(ResourceBase):
         bucket: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
         uid: Optional[str] = None,
-    ) -> "LocalResource":
+    ) -> "LocalResourceBase":
         """
         Resource extension, allowing to pass whole directory as a zipped resource.
 
@@ -304,6 +277,35 @@ class LocalResource(ResourceBase):
                 _flags=flags,
                 _close_fd=True,
             )
+
+
+class LocalResource(LocalResourceBase):
+    """
+    Represents local resource with arbitrary binary data e.g. file contents.
+
+    Local resources will be uploaded to object hub (S3) during
+    task dispatching.
+
+    .. code-block:: python
+
+        # Creating resource from bytes
+        sample = Resource("original_name.exe", content=b"X5O!P%@AP[4\\
+        PZX54(P^)7CC)7}$EICAR-STANDARD-ANT...")
+
+        # Creating resource from path
+        sample = Resource("original_name.exe", path="sample/original_name.exe")
+
+    :param name: Name of the resource (e.g. name of file)
+    :param content: Resource content
+    :param path: Path of file with resource content
+    :param bucket: Alternative S3 bucket for resource
+    :param metadata: Resource metadata
+    :param uid: Alternative S3 resource id
+    :param sha256: Resource sha256 hash
+    :param fd: Seekable file descriptor
+    :param _flags: Resource flags
+    :param _close_fd: Close file descriptor after upload (default: False)
+    """
 
     def _upload(self, backend: "KartonBackend") -> None:
         """Internal function for uploading resources

--- a/karton/core/task.py
+++ b/karton/core/task.py
@@ -3,6 +3,7 @@ import json
 import time
 import uuid
 import warnings
+from contextvars import ContextVar
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -23,6 +24,16 @@ if TYPE_CHECKING:
     from .backend import KartonBackend  # noqa
 
 import orjson
+
+current_task: ContextVar[Optional["Task"]] = ContextVar("current_task")
+
+
+def get_current_task() -> Optional["Task"]:
+    return current_task.get(None)
+
+
+def set_current_task(task: Optional["Task"]):
+    current_task.set(task)
 
 
 class TaskState(enum.Enum):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 redis
 orjson
-# https://github.com/boto/boto3/issues/4392
-boto3<1.36.0
+boto3
+aioboto3

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,4 +11,7 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 [mypy-boto3.*]
 ignore_missing_imports = True
-
+[mypy-aioboto3.*]
+ignore_missing_imports = True
+[mypy-aiobotocore.*]
+ignore_missing_imports = True


### PR DESCRIPTION
Here I'm making a PoC for asyncio support in Karton. Changes improving code reusability between sync/async parts will be isolated into separate PRs.

Changes in core:
- separated some non-I/O code into mixins/bases to reuse them in async code
- global reference to current_task is kept in [contextvar](https://docs.python.org/3/library/contextvars.html#module-contextvars). It is used for automagical binding with current task in logging/Producer.send_task. Theoretically this change may sync code as well because Context Variables are also thread-local, so e.g. thread workers trying to access `self.current_task` from closure will see None, but I hope nobody does such thing.

