### PR TITLE
Various asyncio fixes and improvements

### DIFF
--- a/karton/core/asyncio/base.py
+++ b/karton/core/asyncio/base.py
@@ -52,7 +52,11 @@ class KartonAsyncBase(abc.ABC, ConfigMixin, LoggingMixin):
         )
 
         log_handler = KartonAsyncLogHandler(backend=self.backend, channel=self.identity)
-        LoggingMixin.__init__(self, log_handler)
+        LoggingMixin.__init__(
+            self,
+            log_handler,
+            log_format="[%(asctime)s][%(levelname)s][%(task_id)s] %(message)s",
+        )
 
     async def connect(self) -> None:
         await self.backend.connect()

--- a/karton/core/base.py
+++ b/karton/core/base.py
@@ -106,8 +106,9 @@ class LoggingMixin:
     debug: bool
     enable_publish_log: bool
 
-    def __init__(self, log_handler: logging.Handler):
+    def __init__(self, log_handler: logging.Handler, log_format: str):
         self._log_handler = log_handler
+        self._log_format = log_format
 
     def setup_logger(self, level: Optional[Union[str, int]] = None) -> None:
         """
@@ -146,9 +147,7 @@ class LoggingMixin:
 
         logger.setLevel(log_level)
         stream_handler = logging.StreamHandler()
-        stream_handler.setFormatter(
-            logging.Formatter("[%(asctime)s][%(levelname)s][%(task_id)s] %(message)s")
-        )
+        stream_handler.setFormatter(logging.Formatter(self._log_format))
         logger.addHandler(stream_handler)
 
         if not self.debug and self.enable_publish_log:
@@ -218,7 +217,9 @@ class KartonBase(abc.ABC, ConfigMixin, LoggingMixin):
         )
 
         log_handler = KartonLogHandler(backend=self.backend, channel=self.identity)
-        LoggingMixin.__init__(self, log_handler)
+        LoggingMixin.__init__(
+            self, log_handler, log_format="[%(asctime)s][%(levelname)s] %(message)s"
+        )
 
     @property
     def current_task(self) -> Optional[Task]:

--- a/karton/core/base.py
+++ b/karton/core/base.py
@@ -9,7 +9,7 @@ from typing import Optional, Union, cast
 from .__version__ import __version__
 from .backend import KartonBackend, KartonServiceInfo
 from .config import Config
-from .logger import KartonLogHandler
+from .logger import KartonLogHandler, TaskContextFilter
 from .task import Task, get_current_task, set_current_task
 from .utils import HardShutdownInterrupt, StrictClassMethod, graceful_killer
 
@@ -133,6 +133,7 @@ class LoggingMixin:
         self._log_handler.setFormatter(logging.Formatter())
 
         logger = logging.getLogger(self.identity)
+        logger.addFilter(TaskContextFilter())
 
         if logger.handlers:
             # If logger already have handlers set: clear them
@@ -146,7 +147,7 @@ class LoggingMixin:
         logger.setLevel(log_level)
         stream_handler = logging.StreamHandler()
         stream_handler.setFormatter(
-            logging.Formatter("[%(asctime)s][%(levelname)s] %(message)s")
+            logging.Formatter("[%(asctime)s][%(levelname)s][%(task_id)s] %(message)s")
         )
         logger.addHandler(stream_handler)
 

--- a/karton/core/base.py
+++ b/karton/core/base.py
@@ -106,7 +106,7 @@ class LoggingMixin:
     debug: bool
     enable_publish_log: bool
 
-    def __init__(self, log_handler: logging.Handler, log_format: str):
+    def __init__(self, log_handler: logging.Handler, log_format: str) -> None:
         self._log_handler = log_handler
         self._log_format = log_format
 

--- a/karton/core/config.py
+++ b/karton/core/config.py
@@ -116,6 +116,11 @@ class Config(object):
     @overload
     def getint(self, section_name: str, option_name: str) -> Optional[int]: ...
 
+    @overload
+    def getint(
+        self, section_name: str, option_name: str, fallback: Optional[int]
+    ) -> Optional[int]: ...
+
     def getint(
         self, section_name: str, option_name: str, fallback: Optional[int] = None
     ) -> Optional[int]:

--- a/karton/core/logger.py
+++ b/karton/core/logger.py
@@ -10,6 +10,20 @@ from .task import get_current_task
 HOSTNAME = platform.node()
 
 
+class TaskContextFilter(logging.Filter):
+    """
+    This is a filter which injects information about current task ID to the log.
+    """
+
+    def filter(self, record):
+        current_task = get_current_task()
+        if current_task is not None:
+            record.task_id = current_task.task_uid
+        else:
+            record.task_id = "(no task)"
+        return True
+
+
 class LogLineFormatterMixin:
     format: Callable[[logging.LogRecord], str]
 

--- a/karton/core/logger.py
+++ b/karton/core/logger.py
@@ -15,7 +15,7 @@ class TaskContextFilter(logging.Filter):
     This is a filter which injects information about current task ID to the log.
     """
 
-    def filter(self, record):
+    def filter(self, record: LogRecord) -> bool:
         current_task = get_current_task()
         if current_task is not None:
             record.task_id = current_task.task_uid

--- a/karton/core/logger.py
+++ b/karton/core/logger.py
@@ -15,7 +15,7 @@ class TaskContextFilter(logging.Filter):
     This is a filter which injects information about current task ID to the log.
     """
 
-    def filter(self, record: LogRecord) -> bool:
+    def filter(self, record: logging.LogRecord) -> bool:
         current_task = get_current_task()
         if current_task is not None:
             record.task_id = current_task.task_uid


### PR DESCRIPTION
- Critical fix: releasing concurrency_semaphore after `consume_routed_task` returned None (due to timeout). Right now, consumer is hanging after few seconds.
- Set default concurrency_limit to 1 (much safer default)
- Added task_id to Karton log entries for asyncio Karton services to distinguish records coming from concurrent tasks
