### PR TITLE
Add url and ssl options to Redis configuration

### DIFF
--- a/docs/service_configuration.rst
+++ b/docs/service_configuration.rst
@@ -47,6 +47,8 @@ Common Karton configuration fields are listed below:
  [redis]        username          Redis server AUTH username (default: None)
  [redis]        password          Redis server AUTH password (default: None)
  [redis]        socket_timeout    Socket timeout for Redis operations in seconds (default: 30, use 0 to turn off if timeout doesn't work properly)
+ [redis]        ssl               Use TLS for Redis connection
+ [redis]        url               Redis server url (allows to pass custom arbitrary options)
  [karton]       identity          Karton service identity override (overrides the name provided in class / constructor arguments)
  [karton]       persistent        Karton service queue persistency override
  [karton]       debug             Karton debug mode for service development

--- a/docs/service_configuration.rst
+++ b/docs/service_configuration.rst
@@ -47,8 +47,8 @@ Common Karton configuration fields are listed below:
  [redis]        username          Redis server AUTH username (default: None)
  [redis]        password          Redis server AUTH password (default: None)
  [redis]        socket_timeout    Socket timeout for Redis operations in seconds (default: 30, use 0 to turn off if timeout doesn't work properly)
- [redis]        ssl               Use TLS for Redis connection
- [redis]        url               Redis server url (allows to pass custom arbitrary options)
+ [redis]        ssl               Use TLS for Redis connection (default: 0)
+ [redis]        url               Redis server url (allows passing custom arbitrary options)
  [karton]       identity          Karton service identity override (overrides the name provided in class / constructor arguments)
  [karton]       persistent        Karton service queue persistency override
  [karton]       debug             Karton debug mode for service development

--- a/karton/core/asyncio/backend.py
+++ b/karton/core/asyncio/backend.py
@@ -117,8 +117,9 @@ class KartonAsyncBackend(KartonBackendBase):
                 boto_session._credentials = creds  # type: ignore
                 return aioboto3.Session(botocore_session=boto_session)
 
-    @staticmethod
+    @classmethod
     async def make_redis(
+        cls,
         config,
         identity: Optional[str] = None,
         service_info: Optional[KartonServiceInfo] = None,
@@ -131,22 +132,9 @@ class KartonAsyncBackend(KartonBackendBase):
         :param service_info: Additional service identity metadata
         :return: Redis connection
         """
-        if service_info is not None:
-            client_name: Optional[str] = service_info.make_client_name()
-        else:
-            client_name = identity
-
-        redis_args = {
-            "host": config["redis"]["host"],
-            "port": config.getint("redis", "port", 6379),
-            "db": config.getint("redis", "db", 0),
-            "username": config.get("redis", "username"),
-            "password": config.get("redis", "password"),
-            "client_name": client_name,
-            # set socket_timeout to None if set to 0
-            "socket_timeout": config.getint("redis", "socket_timeout", 30) or None,
-            "decode_responses": True,
-        }
+        redis_args = cls.get_redis_configuration(
+            config, identity=identity, service_info=service_info
+        )
         try:
             rs = Redis(**redis_args)
             await rs.ping()
@@ -154,6 +142,7 @@ class KartonAsyncBackend(KartonBackendBase):
             # Maybe we've sent a wrong password.
             # Or maybe the server is not (yet) password protected
             # To make smooth transition possible, try to login insecurely
+            del redis_args["username"]
             del redis_args["password"]
             rs = Redis(**redis_args)
             await rs.ping()

--- a/karton/core/backend.py
+++ b/karton/core/backend.py
@@ -172,12 +172,8 @@ class KartonBackendBase:
         # Don't set if set to 0
         if socket_timeout := config.get("redis", "socket_timeout", 30):
             redis_conf["socket_timeout"] = socket_timeout
-        redis_conf.update(
-            {
-                "client_name": client_name,
-                "decode_responses": True,
-            }
-        )
+        redis_conf["client_name"] = client_name
+        redis_conf["decode_responses"] = True
         return redis_conf
 
     @staticmethod

--- a/karton/core/backend.py
+++ b/karton/core/backend.py
@@ -167,7 +167,9 @@ class KartonBackendBase:
 
         if username := config.get("redis", "username"):
             redis_conf["username"] = username
-        if password := config.get("redis", "password"):
+            password = config.get("redis", "password")
+            if password is None:
+                raise RuntimeError("You must set both username and password, or none")
             redis_conf["password"] = password
         # Don't set if set to 0
         if socket_timeout := config.get("redis", "socket_timeout", 30):

--- a/karton/core/backend.py
+++ b/karton/core/backend.py
@@ -17,6 +17,7 @@ from botocore.credentials import (
 from botocore.session import get_session
 from redis import AuthenticationError, StrictRedis
 from redis.client import Pipeline
+from redis.connection import parse_url as parse_redis_url
 from urllib3.response import HTTPResponse
 
 from .config import Config
@@ -141,6 +142,43 @@ class KartonBackendBase:
         if not bucket_name:
             raise RuntimeError("S3 default bucket is not defined in configuration")
         return bucket_name
+
+    @staticmethod
+    def get_redis_configuration(
+        config: Config,
+        identity: Optional[str] = None,
+        service_info: Optional[KartonServiceInfo] = None,
+    ) -> Dict[str, Any]:
+        if service_info is not None:
+            client_name: Optional[str] = service_info.make_client_name()
+        else:
+            client_name = identity
+
+        redis_url = config.get("redis", "url")
+        if redis_url is not None:
+            redis_conf = parse_redis_url(redis_url)
+        else:
+            redis_conf = {
+                "host": config["redis"]["host"],
+                "port": config.getint("redis", "port", 6379),
+                "db": config.getint("redis", "db", 0),
+                "ssl": config.getboolean("redis", "ssl", False),
+            }
+
+        if username := config.get("redis", "username"):
+            redis_conf["username"] = username
+        if password := config.get("redis", "password"):
+            redis_conf["password"] = password
+        # Don't set if set to 0
+        if socket_timeout := config.get("redis", "socket_timeout", 30):
+            redis_conf["socket_timeout"] = socket_timeout
+        redis_conf.update(
+            {
+                "client_name": client_name,
+                "decode_responses": True,
+            }
+        )
+        return redis_conf
 
     @staticmethod
     def get_queue_name(identity: str, priority: TaskPriority) -> str:
@@ -302,8 +340,9 @@ class KartonBackend(KartonBackendBase):
                     endpoint_url=endpoint,
                 )
 
-    @staticmethod
+    @classmethod
     def make_redis(
+        cls,
         config,
         identity: Optional[str] = None,
         service_info: Optional[KartonServiceInfo] = None,
@@ -316,22 +355,9 @@ class KartonBackend(KartonBackendBase):
         :param service_info: Additional service identity metadata
         :return: Redis connection
         """
-        if service_info is not None:
-            client_name: Optional[str] = service_info.make_client_name()
-        else:
-            client_name = identity
-
-        redis_args = {
-            "host": config["redis"]["host"],
-            "port": config.getint("redis", "port", 6379),
-            "db": config.getint("redis", "db", 0),
-            "username": config.get("redis", "username"),
-            "password": config.get("redis", "password"),
-            "client_name": client_name,
-            # set socket_timeout to None if set to 0
-            "socket_timeout": config.getint("redis", "socket_timeout", 30) or None,
-            "decode_responses": True,
-        }
+        redis_args = cls.get_redis_configuration(
+            config, identity=identity, service_info=service_info
+        )
         try:
             redis = StrictRedis(**redis_args)
             redis.ping()
@@ -339,6 +365,7 @@ class KartonBackend(KartonBackendBase):
             # Maybe we've sent a wrong password.
             # Or maybe the server is not (yet) password protected
             # To make smooth transition possible, try to login insecurely
+            del redis_args["username"]
             del redis_args["password"]
             redis = StrictRedis(**redis_args)
             redis.ping()


### PR DESCRIPTION
Additional details:

- Configuration dict is built in KartonBackendBase
- Added `del redis_args["username"], because `del redis_args["password"]` just returns error about wrong number of AUTH arguments. Personally I'm against such fallbacks but let's just fix it this time.

closes https://github.com/CERT-Polska/karton/issues/280