### PR TITLE
Config: lazy env var resolving and trying multiple variants

### DIFF
--- a/karton/core/test.py
+++ b/karton/core/test.py
@@ -22,7 +22,8 @@ log = logging.getLogger()
 
 class ConfigMock(Config):
     def __init__(self):
-        self._config = {"redis": {}, "s3": {}}
+        self._file_config = {}
+        self._dict_config = {"redis": {}, "s3": {}}
 
 
 class BackendMock:


### PR DESCRIPTION
Eager env var resolving is simple but leads to very weird env var naming when non-alphanumerical characters are used in section names. We can't use `_` because it leads to disambiguity and we can't distinguish section name from option name. Other characters lead to weird naming like: `KARTON_CONFIG-EXTRACTOR_MODULES`.

Even weirder case we have with `[karton]` section that describes basic Karton-specific configuration that applies to Karton services. Env vars for these fields have form `KARTON_KARTON_IDENTITY`.

This PR:
- changes env var resolving from eager to lazy. Users can't rely on static `_config` dictionary contents and must use `get*` methods to resolve configuration values.
- more simple variants of env names are tried:
    -  `identity` option in `[karton]` section can be configured via `KARTON_IDENTITY` env var, but `KARTON_KARTON_IDENTITY` is also tried for compatibility
    - `modules` option in `[config-extractor]` section can be configured via `KARTON_CONFIG_EXTRACTOR_MODULES` env var, but `KARTON_CONFIG-EXTRACTOR_MODULES` is also checked
 
Hopefully no breaking changes are included in this PR but I had to modify behavior of few functions a bit e.g. `_map_minio_to_s3` map only specific values and `__getitem__` returns special proxy object. 