### PR TITLE
[v6] Introduce backend factory and KartonBackendProtocol interface

### DIFF
--- a/karton/core/asyncio/backend/__init__.py
+++ b/karton/core/asyncio/backend/__init__.py
@@ -1,0 +1,20 @@
+from typing import Optional
+
+from karton.core.backend import KartonServiceInfo
+from karton.core.config import Config
+
+from .base import KartonAsyncBackendProtocol
+from .direct import KartonAsyncBackend
+
+
+def get_backend(
+    config: Config, identity: Optional[str], service_info: Optional[KartonServiceInfo]
+) -> KartonAsyncBackendProtocol:
+    return KartonAsyncBackend(config, identity=identity, service_info=service_info)
+
+
+__all__ = [
+    "KartonAsyncBackend",
+    "KartonAsyncBackendProtocol",
+    "get_backend",
+]

--- a/karton/core/asyncio/backend/base.py
+++ b/karton/core/asyncio/backend/base.py
@@ -2,9 +2,8 @@ from typing import IO, Any
 
 from typing_extensions import Protocol
 
-from karton.core import Task
 from karton.core.backend import KartonBind, KartonMetrics
-from karton.core.task import TaskState
+from karton.core.task import Task, TaskState
 
 
 class KartonAsyncBackendProtocol(Protocol):

--- a/karton/core/asyncio/backend/base.py
+++ b/karton/core/asyncio/backend/base.py
@@ -8,7 +8,9 @@ from karton.core.task import Task, TaskState
 
 class KartonAsyncBackendProtocol(Protocol):
     """
-    Interface for KartonAsyncBackend high-level methods used by producers and consumers
+    Protocol that defines methods that KartonAsyncBackend must implement.
+
+    Used by producers and consumers to avoid depending on a concrete implementation.
     """
 
     async def connect(self) -> None: ...

--- a/karton/core/asyncio/backend/base.py
+++ b/karton/core/asyncio/backend/base.py
@@ -1,0 +1,52 @@
+from typing import IO, Any
+
+from typing_extensions import Protocol
+
+from karton.core import Task
+from karton.core.backend import KartonBind, KartonMetrics
+from karton.core.task import TaskState
+
+
+class KartonAsyncBackendProtocol(Protocol):
+    """
+    Interface for KartonAsyncBackend high-level methods used by producers and consumers
+    """
+
+    async def connect(self) -> None: ...
+
+    async def declare_task(self, task: Task) -> None: ...
+
+    async def set_task_status(self, task: Task, status: TaskState) -> None: ...
+
+    async def get_bind(self, identity: str) -> KartonBind: ...
+
+    async def register_bind(self, bind: KartonBind) -> KartonBind | None: ...
+
+    async def produce_unrouted_task(self, task: Task) -> None: ...
+
+    async def consume_routed_task(
+        self, identity: str, timeout: int = 5
+    ) -> Task | None: ...
+
+    async def increment_metrics(self, metric: KartonMetrics, identity: str) -> None: ...
+
+    async def upload_object(
+        self,
+        bucket: str,
+        object_uid: str,
+        content: bytes | IO[bytes],
+    ) -> None: ...
+
+    async def upload_object_from_file(
+        self, bucket: str, object_uid: str, path: str
+    ) -> None: ...
+
+    async def download_object(self, bucket: str, object_uid: str) -> bytes: ...
+
+    async def download_object_to_file(
+        self, bucket: str, object_uid: str, path: str
+    ) -> None: ...
+
+    async def produce_log(
+        self, log_record: dict[str, Any], logger_name: str, level: str
+    ) -> bool: ...

--- a/karton/core/asyncio/backend/direct.py
+++ b/karton/core/asyncio/backend/direct.py
@@ -12,15 +12,14 @@ from redis.asyncio.client import Pipeline
 from redis.exceptions import AuthenticationError
 
 from karton.core import Config, Task
+from karton.core.asyncio.backend.base import KartonAsyncBackendProtocol
 from karton.core.asyncio.resource import LocalResource, RemoteResource
-from karton.core.backend import (
+from karton.core.backend import KartonBind, KartonMetrics, KartonServiceInfo
+from karton.core.backend.direct import (
     KARTON_BINDS_HSET,
     KARTON_TASK_NAMESPACE,
     KARTON_TASKS_QUEUE,
     KartonBackendBase,
-    KartonBind,
-    KartonMetrics,
-    KartonServiceInfo,
 )
 from karton.core.resource import LocalResource as SyncLocalResource
 from karton.core.task import TaskState
@@ -28,7 +27,7 @@ from karton.core.task import TaskState
 logger = logging.getLogger(__name__)
 
 
-class KartonAsyncBackend(KartonBackendBase):
+class KartonAsyncBackend(KartonBackendBase, KartonAsyncBackendProtocol):
     def __init__(
         self,
         config: Config,
@@ -66,7 +65,7 @@ class KartonAsyncBackend(KartonBackendBase):
                 aws_secret_access_key=secret_key,
             )
 
-    async def connect(self):
+    async def connect(self) -> None:
         if self._redis is not None or self._s3_session is not None:
             # Already connected
             return

--- a/karton/core/asyncio/backend/direct.py
+++ b/karton/core/asyncio/backend/direct.py
@@ -11,7 +11,6 @@ from redis.asyncio import Redis
 from redis.asyncio.client import Pipeline
 from redis.exceptions import AuthenticationError
 
-from karton.core import Config, Task
 from karton.core.asyncio.backend.base import KartonAsyncBackendProtocol
 from karton.core.asyncio.resource import LocalResource, RemoteResource
 from karton.core.backend import KartonBind, KartonMetrics, KartonServiceInfo
@@ -21,8 +20,9 @@ from karton.core.backend.direct import (
     KARTON_TASKS_QUEUE,
     KartonBackendBase,
 )
+from karton.core.config import Config
 from karton.core.resource import LocalResource as SyncLocalResource
-from karton.core.task import TaskState
+from karton.core.task import Task, TaskState
 
 logger = logging.getLogger(__name__)
 

--- a/karton/core/asyncio/karton.py
+++ b/karton/core/asyncio/karton.py
@@ -14,7 +14,7 @@ from karton.core.config import Config
 from karton.core.exceptions import TaskTimeoutError
 from karton.core.task import Task, TaskState
 
-from .backend import KartonAsyncBackend
+from .backend import KartonAsyncBackendProtocol
 from .base import KartonAsyncBase, KartonAsyncServiceBase
 from .resource import LocalResource
 
@@ -56,7 +56,7 @@ class Producer(KartonAsyncBase):
         self,
         config: Optional[Config] = None,
         identity: Optional[str] = None,
-        backend: Optional[KartonAsyncBackend] = None,
+        backend: Optional[KartonAsyncBackendProtocol] = None,
     ) -> None:
         super().__init__(config=config, identity=identity, backend=backend)
 
@@ -119,7 +119,7 @@ class Consumer(KartonAsyncServiceBase):
         self,
         config: Optional[Config] = None,
         identity: Optional[str] = None,
-        backend: Optional[KartonAsyncBackend] = None,
+        backend: Optional[KartonAsyncBackendProtocol] = None,
     ) -> None:
         super().__init__(config=config, identity=identity, backend=backend)
 
@@ -359,6 +359,6 @@ class Karton(Consumer, Producer):
         self,
         config: Optional[Config] = None,
         identity: Optional[str] = None,
-        backend: Optional[KartonAsyncBackend] = None,
+        backend: Optional[KartonAsyncBackendProtocol] = None,
     ) -> None:
         super().__init__(config=config, identity=identity, backend=backend)

--- a/karton/core/asyncio/logger.py
+++ b/karton/core/asyncio/logger.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, Optional, Tuple
 
 from karton.core.logger import LogLineFormatterMixin
 
-from .backend import KartonAsyncBackend
+from .backend import KartonAsyncBackendProtocol
 
 HOSTNAME = platform.node()
 
@@ -17,7 +17,9 @@ QueuedRecord = Optional[Tuple[Dict[str, Any], str]]
 
 
 async def async_log_consumer(
-    queue: asyncio.Queue[QueuedRecord], backend: KartonAsyncBackend, channel: str
+    queue: asyncio.Queue[QueuedRecord],
+    backend: KartonAsyncBackendProtocol,
+    channel: str,
 ) -> None:
     while True:
         item = await queue.get()
@@ -32,7 +34,7 @@ class KartonAsyncLogHandler(logging.Handler, LogLineFormatterMixin):
     logging.Handler that passes logs to the Karton backend.
     """
 
-    def __init__(self, backend: KartonAsyncBackend, channel: str) -> None:
+    def __init__(self, backend: KartonAsyncBackendProtocol, channel: str) -> None:
         logging.Handler.__init__(self)
         self._consumer: Optional[asyncio.Task] = None
         self._queue: asyncio.Queue[QueuedRecord] = asyncio.Queue()

--- a/karton/core/asyncio/resource.py
+++ b/karton/core/asyncio/resource.py
@@ -9,7 +9,7 @@ from typing import IO, TYPE_CHECKING, Any, AsyncIterator, Dict, List, Optional, 
 from karton.core.resource import LocalResourceBase, ResourceBase
 
 if TYPE_CHECKING:
-    from .backend import KartonAsyncBackend
+    from .backend import KartonAsyncBackendProtocol
 
 
 class LocalResource(LocalResourceBase):
@@ -66,7 +66,7 @@ class LocalResource(LocalResourceBase):
             _close_fd=_close_fd,
         )
 
-    async def _upload(self, backend: "KartonAsyncBackend") -> None:
+    async def _upload(self, backend: "KartonAsyncBackendProtocol") -> None:
         """Internal function for uploading resources
 
         :param backend: KartonBackend to use while uploading the resource
@@ -101,7 +101,7 @@ class LocalResource(LocalResourceBase):
             # Upload file provided by path
             await backend.upload_object_from_file(self.bucket, self.uid, self._path)
 
-    async def upload(self, backend: "KartonAsyncBackend") -> None:
+    async def upload(self, backend: "KartonAsyncBackendProtocol") -> None:
         """Internal function for uploading resources
 
         :param backend: KartonBackend to use while uploading the resource
@@ -141,7 +141,7 @@ class RemoteResource(ResourceBase):
         metadata: Optional[Dict[str, Any]] = None,
         uid: Optional[str] = None,
         size: Optional[int] = None,
-        backend: Optional["KartonAsyncBackend"] = None,
+        backend: Optional["KartonAsyncBackendProtocol"] = None,
         sha256: Optional[str] = None,
         _flags: Optional[List[str]] = None,
     ) -> None:
@@ -179,7 +179,7 @@ class RemoteResource(ResourceBase):
 
     @classmethod
     def from_dict(
-        cls, dict: Dict[str, Any], backend: Optional["KartonAsyncBackend"]
+        cls, dict: Dict[str, Any], backend: Optional["KartonAsyncBackendProtocol"]
     ) -> "RemoteResource":
         """
         Internal deserialization method for remote resources

--- a/karton/core/backend/__init__.py
+++ b/karton/core/backend/__init__.py
@@ -1,0 +1,22 @@
+from typing import Optional
+
+from karton.core.config import Config
+
+from .base import KartonBackendProtocol, KartonBind, KartonMetrics, KartonServiceInfo
+from .direct import KartonBackend
+
+
+def get_backend(
+    config: Config, identity: Optional[str], service_info: Optional[KartonServiceInfo]
+) -> KartonBackendProtocol:
+    return KartonBackend(config, identity=identity, service_info=service_info)
+
+
+__all__ = [
+    "KartonBackend",
+    "KartonBind",
+    "KartonMetrics",
+    "KartonServiceInfo",
+    "KartonBackendProtocol",
+    "get_backend",
+]

--- a/karton/core/backend/base.py
+++ b/karton/core/backend/base.py
@@ -1,0 +1,116 @@
+import dataclasses
+import enum
+import urllib.parse
+from collections import namedtuple
+from typing import IO, Any, Iterator, Protocol
+
+from karton.core import Task
+from karton.core.task import TaskState
+
+KartonBind = namedtuple(
+    "KartonBind",
+    [
+        "identity",
+        "info",
+        "version",
+        "persistent",
+        "filters",
+        "service_version",
+        "is_async",
+    ],
+)
+
+
+class KartonMetrics(enum.Enum):
+    TASK_PRODUCED = "karton.metrics.produced"
+    TASK_CONSUMED = "karton.metrics.consumed"
+    TASK_CRASHED = "karton.metrics.crashed"
+    TASK_ASSIGNED = "karton.metrics.assigned"
+    TASK_GARBAGE_COLLECTED = "karton.metrics.garbage-collected"
+
+
+@dataclasses.dataclass(frozen=True)
+class KartonServiceInfo:
+    """
+    Extended Karton service information.
+
+    Instances of this dataclass are meant to be aggregated to count service replicas
+    in Karton Dashboard. They're considered equal if identity and versions strings
+    are the same.
+    """
+
+    identity: str
+    karton_version: str
+    service_version: str | None = None
+
+
+class KartonBackendProtocol(Protocol):
+    """
+    Interface for KartonBackend high-level methods used by producers and consumers
+    """
+
+    def declare_task(self, task: Task) -> None: ...
+
+    def set_task_status(self, task: Task, status: TaskState) -> None: ...
+
+    def get_bind(self, identity: str) -> KartonBind: ...
+
+    def register_bind(self, bind: KartonBind) -> KartonBind | None: ...
+
+    def produce_unrouted_task(self, task: Task) -> None: ...
+
+    def consume_routed_task(self, identity: str, timeout: int = 5) -> Task | None: ...
+
+    def increment_metrics(self, metric: KartonMetrics, identity: str) -> None: ...
+
+    def upload_object(
+        self,
+        bucket: str,
+        object_uid: str,
+        content: bytes | IO[bytes],
+    ) -> None: ...
+
+    def upload_object_from_file(
+        self, bucket: str, object_uid: str, path: str
+    ) -> None: ...
+
+    def download_object(self, bucket: str, object_uid: str) -> bytes: ...
+
+    def download_object_to_file(
+        self, bucket: str, object_uid: str, path: str
+    ) -> None: ...
+
+    def produce_log(
+        self, log_record: dict[str, Any], logger_name: str, level: str
+    ) -> bool: ...
+
+    def remove_object(self, bucket: str, object_uid: str) -> None: ...
+
+    def consume_log(
+        self,
+        timeout: int = 5,
+        logger_filter: str | None = None,
+        level: str | None = None,
+    ) -> Iterator[dict[str, Any] | None]: ...
+
+
+def make_redis_client_name(service_info: KartonServiceInfo) -> str:
+    params = {
+        "karton_version": service_info.karton_version,
+    }
+    if service_info.service_version is not None:
+        params.update({"service_version": service_info.service_version})
+    return f"{service_info.identity}?{urllib.parse.urlencode(params)}"
+
+
+def parse_redis_client_name(client_name: str) -> KartonServiceInfo:
+    identity, params_string = client_name.split("?", 1)
+    # Filter out unknown params to not get crashed by future extensions
+    params = dict(urllib.parse.parse_qsl(params_string))
+    karton_version = params.get("karton_version", "")
+    service_version = params.get("service_version")
+    return KartonServiceInfo(
+        identity=identity,
+        karton_version=karton_version,
+        service_version=service_version,
+    )

--- a/karton/core/backend/base.py
+++ b/karton/core/backend/base.py
@@ -44,7 +44,9 @@ class KartonServiceInfo:
 
 class KartonBackendProtocol(Protocol):
     """
-    Interface for KartonBackend high-level methods used by producers and consumers
+    Protocol that defines methods that KartonBackend must implement.
+
+    Used by producers and consumers to avoid depending on a concrete implementation.
     """
 
     def declare_task(self, task: Task) -> None: ...

--- a/karton/core/backend/base.py
+++ b/karton/core/backend/base.py
@@ -3,8 +3,7 @@ import enum
 from collections import namedtuple
 from typing import IO, Any, Iterator, Protocol
 
-from karton.core import Task
-from karton.core.task import TaskState
+from karton.core.task import Task, TaskState
 
 KartonBind = namedtuple(
     "KartonBind",

--- a/karton/core/backend/base.py
+++ b/karton/core/backend/base.py
@@ -1,6 +1,5 @@
 import dataclasses
 import enum
-import urllib.parse
 from collections import namedtuple
 from typing import IO, Any, Iterator, Protocol
 
@@ -92,25 +91,3 @@ class KartonBackendProtocol(Protocol):
         logger_filter: str | None = None,
         level: str | None = None,
     ) -> Iterator[dict[str, Any] | None]: ...
-
-
-def make_redis_client_name(service_info: KartonServiceInfo) -> str:
-    params = {
-        "karton_version": service_info.karton_version,
-    }
-    if service_info.service_version is not None:
-        params.update({"service_version": service_info.service_version})
-    return f"{service_info.identity}?{urllib.parse.urlencode(params)}"
-
-
-def parse_redis_client_name(client_name: str) -> KartonServiceInfo:
-    identity, params_string = client_name.split("?", 1)
-    # Filter out unknown params to not get crashed by future extensions
-    params = dict(urllib.parse.parse_qsl(params_string))
-    karton_version = params.get("karton_version", "")
-    service_version = params.get("service_version")
-    return KartonServiceInfo(
-        identity=identity,
-        karton_version=karton_version,
-        service_version=service_version,
-    )

--- a/karton/core/backend/direct.py
+++ b/karton/core/backend/direct.py
@@ -48,7 +48,6 @@ def make_redis_client_name(service_info: KartonServiceInfo) -> str:
 
 def parse_redis_client_name(client_name: str) -> KartonServiceInfo:
     identity, params_string = client_name.split("?", 1)
-    # Filter out unknown params to not get crashed by future extensions
     params = dict(urllib.parse.parse_qsl(params_string))
     karton_version = params.get("karton_version", "")
     service_version = params.get("service_version")

--- a/karton/core/base.py
+++ b/karton/core/base.py
@@ -4,10 +4,10 @@ import logging
 import os
 import textwrap
 from contextlib import contextmanager
-from typing import Optional, Union, cast
+from typing import Optional, Protocol, Union, cast
 
 from .__version__ import __version__
-from .backend import KartonBackend, KartonServiceInfo
+from .backend import KartonBackendProtocol, KartonServiceInfo, get_backend
 from .config import Config
 from .logger import KartonLogHandler, TaskContextFilter
 from .task import Task, get_current_task, set_current_task
@@ -19,8 +19,8 @@ class ConfigMixin:
     version: Optional[str]
 
     def __init__(self, config: Optional[Config] = None, identity: Optional[str] = None):
-        self.config = config or Config()
-        self.enable_publish_log = self.config.getboolean(
+        self.config: Config = config or Config()
+        self.enable_publish_log: bool = self.config.getboolean(
             "logging", "enable_publish", True
         )
 
@@ -32,7 +32,7 @@ class ConfigMixin:
         if self.config.has_option("karton", "identity"):
             self.identity = self.config.get("karton", "identity")
 
-        self.debug = self.config.getboolean("karton", "debug", False)
+        self.debug: bool = self.config.getboolean("karton", "debug", False)
 
         if self.debug and self.identity:
             self.identity += "-" + os.urandom(4).hex() + "-dev"
@@ -181,6 +181,15 @@ class LoggingMixin:
         return logging.getLogger(self.identity)
 
 
+class KartonBackendFactory(Protocol):
+    def __call__(
+        self,
+        config: Config,
+        identity: Optional[str],
+        service_info: Optional[KartonServiceInfo],
+    ) -> KartonBackendProtocol: ...
+
+
 class KartonBase(abc.ABC, ConfigMixin, LoggingMixin):
     """
     Base class for all Karton services
@@ -195,12 +204,14 @@ class KartonBase(abc.ABC, ConfigMixin, LoggingMixin):
     version: Optional[str] = None
     #: Include extended service information for non-consumer services
     with_service_info: bool = False
+    backend: KartonBackendProtocol
+    _backend_factory: KartonBackendFactory = staticmethod(get_backend)
 
     def __init__(
         self,
         config: Optional[Config] = None,
         identity: Optional[str] = None,
-        backend: Optional[KartonBackend] = None,
+        backend: Optional[KartonBackendProtocol] = None,
     ) -> None:
         ConfigMixin.__init__(self, config, identity)
 
@@ -212,7 +223,7 @@ class KartonBase(abc.ABC, ConfigMixin, LoggingMixin):
                 service_version=self.version,
             )
 
-        self.backend = backend or KartonBackend(
+        self.backend = backend or self._backend_factory(
             self.config, identity=self.identity, service_info=self.service_info
         )
 
@@ -246,7 +257,7 @@ class KartonServiceBase(KartonBase):
         self,
         config: Optional[Config] = None,
         identity: Optional[str] = None,
-        backend: Optional[KartonBackend] = None,
+        backend: Optional[KartonBackendProtocol] = None,
     ) -> None:
         super().__init__(
             config=config,

--- a/karton/core/karton.py
+++ b/karton/core/karton.py
@@ -11,7 +11,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, cast
 
 from . import query
 from .__version__ import __version__
-from .backend import KartonBackend, KartonBind, KartonMetrics
+from .backend import KartonBackendProtocol, KartonBind, KartonMetrics
 from .base import KartonBase, KartonServiceBase
 from .config import Config
 from .exceptions import TaskTimeoutError
@@ -56,7 +56,7 @@ class Producer(KartonBase):
         self,
         config: Optional[Config] = None,
         identity: Optional[str] = None,
-        backend: Optional[KartonBackend] = None,
+        backend: Optional[KartonBackendProtocol] = None,
     ) -> None:
         super().__init__(config=config, identity=identity, backend=backend)
 
@@ -110,13 +110,13 @@ class Consumer(KartonServiceBase):
     filters: List[Dict[str, Any]] = []
     persistent: bool = True
     version: Optional[str] = None
-    task_timeout = None
+    task_timeout: Optional[int] = None
 
     def __init__(
         self,
         config: Optional[Config] = None,
         identity: Optional[str] = None,
-        backend: Optional[KartonBackend] = None,
+        backend: Optional[KartonBackendProtocol] = None,
     ) -> None:
         super().__init__(config=config, identity=identity, backend=backend)
 
@@ -389,7 +389,7 @@ class LogConsumer(KartonServiceBase):
         self,
         config: Optional[Config] = None,
         identity: Optional[str] = None,
-        backend: Optional[KartonBackend] = None,
+        backend: Optional[KartonBackendProtocol] = None,
     ) -> None:
         super().__init__(config=config, identity=identity, backend=backend)
 
@@ -441,7 +441,7 @@ class Karton(Consumer, Producer):
         self,
         config: Optional[Config] = None,
         identity: Optional[str] = None,
-        backend: Optional[KartonBackend] = None,
+        backend: Optional[KartonBackendProtocol] = None,
     ) -> None:
         super().__init__(config=config, identity=identity, backend=backend)
 

--- a/karton/core/logger.py
+++ b/karton/core/logger.py
@@ -4,7 +4,7 @@ import traceback
 import warnings
 from typing import Any, Callable, Dict
 
-from .backend import KartonBackend
+from .backend import KartonBackendProtocol
 from .task import get_current_task
 
 HOSTNAME = platform.node()
@@ -69,7 +69,7 @@ class KartonLogHandler(logging.Handler, LogLineFormatterMixin):
     logging.Handler that passes logs to the Karton backend.
     """
 
-    def __init__(self, backend: KartonBackend, channel: str) -> None:
+    def __init__(self, backend: KartonBackendProtocol, channel: str) -> None:
         logging.Handler.__init__(self)
         self.backend = backend
         self.is_consumer_active: bool = True

--- a/karton/core/resource.py
+++ b/karton/core/resource.py
@@ -9,7 +9,7 @@ from io import BytesIO
 from typing import IO, TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Union, cast
 
 if TYPE_CHECKING:
-    from .backend import KartonBackend
+    from .backend import KartonBackendProtocol
 
 
 class ResourceBase(object):
@@ -307,7 +307,7 @@ class LocalResource(LocalResourceBase):
     :param _close_fd: Close file descriptor after upload (default: False)
     """
 
-    def _upload(self, backend: "KartonBackend") -> None:
+    def _upload(self, backend: "KartonBackendProtocol") -> None:
         """Internal function for uploading resources
 
         :param backend: KartonBackend to use while uploading the resource
@@ -342,7 +342,7 @@ class LocalResource(LocalResourceBase):
             # Upload file provided by path
             backend.upload_object_from_file(self.bucket, self.uid, self._path)
 
-    def upload(self, backend: "KartonBackend") -> None:
+    def upload(self, backend: "KartonBackendProtocol") -> None:
         """Internal function for uploading resources
 
         :param backend: KartonBackend to use while uploading the resource
@@ -382,7 +382,7 @@ class RemoteResource(ResourceBase):
         metadata: Optional[Dict[str, Any]] = None,
         uid: Optional[str] = None,
         size: Optional[int] = None,
-        backend: Optional["KartonBackend"] = None,
+        backend: Optional["KartonBackendProtocol"] = None,
         sha256: Optional[str] = None,
         _flags: Optional[List[str]] = None,
     ) -> None:
@@ -407,7 +407,7 @@ class RemoteResource(ResourceBase):
 
     @classmethod
     def from_dict(
-        cls, dict: Dict[str, Any], backend: Optional["KartonBackend"]
+        cls, dict: Dict[str, Any], backend: Optional["KartonBackendProtocol"]
     ) -> "RemoteResource":
         """
         Internal deserialization method for remote resources

--- a/karton/core/task.py
+++ b/karton/core/task.py
@@ -21,7 +21,7 @@ from .resource import RemoteResource, ResourceBase
 from .utils import recursive_iter, recursive_iter_with_keys, recursive_map
 
 if TYPE_CHECKING:
-    from .backend import KartonBackend  # noqa
+    from .backend import KartonBackendProtocol  # noqa
 
 import orjson
 
@@ -384,7 +384,7 @@ class Task(object):
     @staticmethod
     def unserialize(
         data: Union[str, bytes],
-        backend: Optional["KartonBackend"] = None,
+        backend: Optional["KartonBackendProtocol"] = None,
         parse_resources: bool = True,
         resource_unserializer: Optional[Callable[[Dict], Any]] = None,
     ) -> "Task":

--- a/karton/system/system.py
+++ b/karton/system/system.py
@@ -5,12 +5,8 @@ from typing import List, Optional
 
 from karton.core import query
 from karton.core.__version__ import __version__
-from karton.core.backend import (
-    KARTON_OPERATIONS_QUEUE,
-    KARTON_TASKS_QUEUE,
-    KartonBind,
-    KartonMetrics,
-)
+from karton.core.backend import KartonBackend, KartonBind, KartonMetrics
+from karton.core.backend.direct import KARTON_OPERATIONS_QUEUE, KARTON_TASKS_QUEUE
 from karton.core.base import KartonServiceBase
 from karton.core.config import Config
 from karton.core.task import Task, TaskState
@@ -25,6 +21,8 @@ class SystemService(KartonServiceBase):
     identity = "karton.system"
     version = __version__
     with_service_info = True
+    backend: KartonBackend
+    _backend_factory = KartonBackend
 
     CRASH_STARTED_TASKS_ON_TIMEOUT = False
     GC_INTERVAL = 3 * 60

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "Operating System :: OS Independent"
 ]
 dynamic = ["version", "dependencies"]
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 
 [project.urls]
 Homepage = "https://github.com/CERT-Polska/karton"
@@ -27,7 +27,13 @@ karton-system = "karton.system:SystemService.main"
 karton = "karton.core.main:main"
 
 [tool.setuptools]
-packages = ["karton.core", "karton.core.asyncio", "karton.system"]
+packages = [
+    "karton.core",
+    "karton.core.asyncio",
+    "karton.core.backend",
+    "karton.core.asyncio.backend",
+    "karton.system"
+]
 
 [tool.setuptools.dynamic]
 version = {attr = "karton.core.__version__.__version__"}
@@ -50,7 +56,7 @@ extra-requirements = "redis<5.0.0 botocore-stubs"
 [tool.mypy]
 explicit_package_bases = true
 namespace_packages = true
-python_version = "3.8"
+python_version = "3.10"
 
 [[tool.mypy.overrides]]
 module = "urllib3.*"


### PR DESCRIPTION
This is a first PR introducing changes required for implementing an alternative Karton backend called "Karton Gateway". It's going to use websockets and presigned S3 URLs instead of relying on Redis and S3 operations directly.

- Karton services (Consumers, Producers, integrations) are going to use `get_backend` method to create appropriate backend based on Karton configuration (`karton.ini`).
- Backend interface for services is well defined by [Protocol](https://typing.python.org/en/latest/spec/protocol.html) and defines set of methods that must be implemented in all backends used by Karton services.
- Internal services still use "direct" backend to perform operations directly on Redis/S3. Karton System uses the sync direct backend and future Karton Gateway server is going to use the async direct backend.

Additional changes:

- `KartonServiceInfo.make_client_name` is moved to static function `make_redis_client_name` and `KartonServiceInfo.parse_client_name` is moved to static function `parse_redis_client_name`. KartonServiceInfo is part of common interface and should contain anything Redis-related.
- Removed `KartonServiceInfo.redis_client_info`. This property contained Redis client information coming from [`CLIENT INFO`](https://redis.io/docs/latest/commands/client-info/) but wasn't used anywhere.
- **Bumped required Python version to 3.10**. I hit bug in mypy (https://github.com/python/mypy/issues/4574) that is caused by the fact that staticmethod is not directly callable in Python versions older than 3.10 (see also https://github.com/python/cpython/issues/87848).
   The runtime itself isn't affected by this bug, but EOL for Python 3.9 is 31 Oct 2025. We will be really close to that date when releasing anything from `develop-v6` branch, so it's not worth to stick to the Py3.9. That's also the reason why I used [PEP 604 style union types (X | Y)](https://peps.python.org/pep-0604/) introduced in Python 3.10. I also use [PEP 585 - Type Hinting Generics In Standard Collections](https://peps.python.org/pep-0585/) that are introduced in Python 3.9.