### PR TITLE
Refactor: Make KartonServiceInfo the default method for service identification

### DIFF
--- a/karton/core/asyncio/backend/__init__.py
+++ b/karton/core/asyncio/backend/__init__.py
@@ -8,7 +8,9 @@ from .direct import KartonAsyncBackend
 
 
 def get_backend(
-    config: Config, identity: Optional[str], service_info: Optional[KartonServiceInfo]
+    config: Config,
+    identity: Optional[str] = None,
+    service_info: Optional[KartonServiceInfo] = None,
 ) -> KartonAsyncBackendProtocol:
     return KartonAsyncBackend(config, identity=identity, service_info=service_info)
 

--- a/karton/core/asyncio/backend/direct.py
+++ b/karton/core/asyncio/backend/direct.py
@@ -73,9 +73,7 @@ class KartonAsyncBackend(KartonBackendBase, KartonAsyncBackendProtocol):
         if self._redis is not None or self._s3_session is not None:
             # Already connected
             return
-        self._redis = await self.make_redis(
-            self.config, identity=self.identity, service_info=self.service_info
-        )
+        self._redis = await self.make_redis(self.config, service_info=self.service_info)
 
         endpoint = self.config.get("s3", "address")
         access_key = self.config.get("s3", "access_key")
@@ -125,20 +123,16 @@ class KartonAsyncBackend(KartonBackendBase, KartonAsyncBackendProtocol):
     async def make_redis(
         cls,
         config,
-        identity: Optional[str] = None,
-        service_info: Optional[KartonServiceInfo] = None,
+        service_info: KartonServiceInfo,
     ) -> Redis:
         """
         Create and test a Redis connection.
 
         :param config: The karton configuration
-        :param identity: Karton service identity
         :param service_info: Additional service identity metadata
         :return: Redis connection
         """
-        redis_args = cls.get_redis_configuration(
-            config, identity=identity, service_info=service_info
-        )
+        redis_args = cls.get_redis_configuration(config, service_info=service_info)
         try:
             rs = Redis(**redis_args)
             await rs.ping()

--- a/karton/core/asyncio/base.py
+++ b/karton/core/asyncio/base.py
@@ -20,8 +20,8 @@ class KartonAsyncBackendFactory(Protocol):
     def __call__(
         self,
         config: Config,
-        identity: Optional[str],
-        service_info: Optional[KartonServiceInfo],
+        identity: Optional[str] = None,
+        service_info: Optional[KartonServiceInfo] = None,
     ) -> KartonAsyncBackendProtocol: ...
 
 
@@ -37,8 +37,6 @@ class KartonAsyncBase(abc.ABC, ConfigMixin, LoggingMixin):
     identity: str = ""
     #: Karton service version
     version: Optional[str] = None
-    #: Include extended service information for non-consumer services
-    with_service_info: bool = False
     backend: KartonAsyncBackendProtocol
     _backend_factory: KartonAsyncBackendFactory = staticmethod(get_backend)
 
@@ -50,16 +48,14 @@ class KartonAsyncBase(abc.ABC, ConfigMixin, LoggingMixin):
     ) -> None:
         ConfigMixin.__init__(self, config, identity)
 
-        self.service_info = None
-        if self.identity is not None and self.with_service_info:
-            self.service_info = KartonServiceInfo(
-                identity=self.identity,
-                karton_version=__version__,
-                service_version=self.version,
-            )
+        self.service_info = KartonServiceInfo(
+            identity=self.identity,
+            karton_version=__version__,
+            service_version=self.version,
+        )
 
         self.backend = backend or self._backend_factory(
-            self.config, identity=self.identity, service_info=self.service_info
+            self.config, service_info=self.service_info
         )
 
         log_handler = KartonAsyncLogHandler(backend=self.backend, channel=self.identity)

--- a/karton/core/backend/__init__.py
+++ b/karton/core/backend/__init__.py
@@ -7,7 +7,9 @@ from .direct import KartonBackend
 
 
 def get_backend(
-    config: Config, identity: Optional[str], service_info: Optional[KartonServiceInfo]
+    config: Config,
+    identity: Optional[str] = None,
+    service_info: Optional[KartonServiceInfo] = None,
 ) -> KartonBackendProtocol:
     return KartonBackend(config, identity=identity, service_info=service_info)
 

--- a/karton/core/backend/base.py
+++ b/karton/core/backend/base.py
@@ -59,7 +59,9 @@ def resolve_service_info(
     """
     if service_info is None:
         if identity is None:
-            raise InvalidIdentityError("Identity cannot be None")
+            raise InvalidIdentityError(
+                "Either identity or service_info must be provided"
+            )
         service_info = KartonServiceInfo(
             identity=identity,
             karton_version=__version__,
@@ -69,7 +71,7 @@ def resolve_service_info(
         disallowed_char in service_info.identity for disallowed_char in disallowed_chars
     ):
         raise InvalidIdentityError(
-            f"Karton identity should not contain {disallowed_chars}"
+            f"Karton identity must not contain {disallowed_chars}"
         )
     return service_info
 

--- a/karton/core/backend/base.py
+++ b/karton/core/backend/base.py
@@ -3,6 +3,8 @@ import enum
 from collections import namedtuple
 from typing import IO, Any, Iterator, Protocol
 
+from karton.core.__version__ import __version__
+from karton.core.exceptions import InvalidIdentityError
 from karton.core.resource import LocalResource, RemoteResource
 from karton.core.task import Task, TaskState
 
@@ -41,6 +43,35 @@ class KartonServiceInfo:
     identity: str
     karton_version: str
     service_version: str | None = None
+
+
+def resolve_service_info(
+    identity: str | None, service_info: KartonServiceInfo | None
+) -> KartonServiceInfo:
+    """
+    Makes KartonServiceInfo object from backend parameters that identify the service.
+
+    If only identity is provided: KartonServiceInfo containing only an identity and
+    karton_version information is created.
+
+    This function also validates if identity is correct and doesn't contain disallowed
+    characters.
+    """
+    if service_info is None:
+        if identity is None:
+            raise InvalidIdentityError("Identity cannot be None")
+        service_info = KartonServiceInfo(
+            identity=identity,
+            karton_version=__version__,
+        )
+    disallowed_chars = [" ", "?"]
+    if any(
+        disallowed_char in service_info.identity for disallowed_char in disallowed_chars
+    ):
+        raise InvalidIdentityError(
+            f"Karton identity should not contain {disallowed_chars}"
+        )
+    return service_info
 
 
 class KartonBackendProtocol(Protocol):

--- a/karton/core/base.py
+++ b/karton/core/base.py
@@ -185,8 +185,8 @@ class KartonBackendFactory(Protocol):
     def __call__(
         self,
         config: Config,
-        identity: Optional[str],
-        service_info: Optional[KartonServiceInfo],
+        identity: Optional[str] = None,
+        service_info: Optional[KartonServiceInfo] = None,
     ) -> KartonBackendProtocol: ...
 
 
@@ -202,8 +202,6 @@ class KartonBase(abc.ABC, ConfigMixin, LoggingMixin):
     identity: str = ""
     #: Karton service version
     version: Optional[str] = None
-    #: Include extended service information for non-consumer services
-    with_service_info: bool = False
     backend: KartonBackendProtocol
     _backend_factory: KartonBackendFactory = staticmethod(get_backend)
 
@@ -215,16 +213,14 @@ class KartonBase(abc.ABC, ConfigMixin, LoggingMixin):
     ) -> None:
         ConfigMixin.__init__(self, config, identity)
 
-        self.service_info = None
-        if self.identity is not None and self.with_service_info:
-            self.service_info = KartonServiceInfo(
-                identity=self.identity,
-                karton_version=__version__,
-                service_version=self.version,
-            )
+        self.service_info = KartonServiceInfo(
+            identity=self.identity,
+            karton_version=__version__,
+            service_version=self.version,
+        )
 
         self.backend = backend or self._backend_factory(
-            self.config, identity=self.identity, service_info=self.service_info
+            self.config, service_info=self.service_info
         )
 
         log_handler = KartonLogHandler(backend=self.backend, channel=self.identity)

--- a/karton/core/karton.py
+++ b/karton/core/karton.py
@@ -377,7 +377,6 @@ class LogConsumer(KartonServiceBase):
 
     logger_filter: Optional[str] = None
     level: Optional[str] = None
-    with_service_info = True
 
     def __init__(
         self,

--- a/karton/system/system.py
+++ b/karton/system/system.py
@@ -20,7 +20,6 @@ class SystemService(KartonServiceBase):
 
     identity = "karton.system"
     version = __version__
-    with_service_info = True
     backend: KartonBackend
     _backend_factory = KartonBackend
 


### PR DESCRIPTION
KartonServiceInfo was introduced in v5.1.0 (https://github.com/CERT-Polska/karton/pull/206) to provide extended version information about other Karton services than consumers. It was opt-in in most cases and `with_service_info = True` flag was required to provide such information. 

Karton Gateway works in a bit different model and extended information contained in KartonServiceInfo is part of regular client identification:
```
class HelloRequestMessage(BaseModel):
    identity: str
    service_version: str | None
    library_version: str
    secondary_connection: bool
    credentials: AuthCredentials | None = None
 ```
 
It enables us to use `karton_version` in future for backwards compatibility.

Notes:
- `get_backend` and Backend constructors still accept the identity argument, similarly to Producer/Consumer constructors. When only identity is provided: it is resolved to KartonServiceInfo object with identity and karton_version information only
- The side effect is that Consumers and Producers will appear in Services in Karton dashboard tab. Actually I don't see any huge disadvantage in showing all services there. The only thing worth noting is that occasional Producers may not maintain a stable connection, so their appearance won't be persistent.
- This PR fixes a bug, identity from KartonServiceInfo wasn't validated :smiling_face_with_tear: I guess it shows that it's easier to have a single object with such information.
