### PR TITLE
Fix Task.get_resource typing: returns RemoteResource (or asyncio.RemoteResource)

### DIFF
--- a/karton/core/karton.py
+++ b/karton/core/karton.py
@@ -15,7 +15,7 @@ from .backend import KartonBackendProtocol, KartonBind, KartonMetrics
 from .base import KartonBase, KartonServiceBase
 from .config import Config
 from .exceptions import BindExpiredError, TaskTimeoutError
-from .resource import LocalResource
+from .resource import LocalResource, RemoteResource
 from .task import Task, TaskState
 from .utils import timeout
 
@@ -142,7 +142,7 @@ class Consumer(KartonServiceBase):
         ] = []
 
     @abc.abstractmethod
-    def process(self, task: Task) -> None:
+    def process(self, task: Task[RemoteResource]) -> None:
         """
         Task processing method.
 
@@ -154,7 +154,7 @@ class Consumer(KartonServiceBase):
         """
         raise NotImplementedError()
 
-    def internal_process(self, task: Task) -> None:
+    def internal_process(self, task: Task[RemoteResource]) -> None:
         """
         The internal side of :py:meth:`Consumer.process` function, takes care of
         synchronizing the task state, handling errors and running task hooks.
@@ -357,7 +357,7 @@ class Consumer(KartonServiceBase):
                     self.log.info("%s", e)
                     break
                 if task:
-                    self.internal_process(task)
+                    self.internal_process(cast(Task[RemoteResource], task))
 
 
 class LogConsumer(KartonServiceBase):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ orjson
 # See also https://github.com/CERT-Polska/karton/pull/270
 boto3<=1.35.81
 aioboto3==13.3.0
+typing-extensions


### PR DESCRIPTION
Current typing of Task.get_resource return value is a bit annoying. It's set to ResourceBase which is generic type without `download()` methods, so if we use a type-checker in Consumer code, we need explicit casting to the RemoteResource.

This PR makes Task a generic type where specialization defines the resource type it holds. If type is not specialized, it is set to ResourceBase (we use [PEP 696 - Type Defaults for Type Parameters](https://peps.python.org/pep-0696/) feature added in Python 3.13 that is backported via `typing-extensions`). 

This change shouldn't require any changes in Consumer code. If someone doesn't specify Task specialization, `get_resource()` return type will be ResourceBase (unless explicitly casted)

```python
from karton.core import Task, Consumer

class SimpleConsumer(Consumer):
    identity = "karton.simple-consumer"

    def process(self, task: Task) -> None:
        sample = task.get_resource("ddd")
        sample.download() # error: "ResourceBase" has no attribute "download"
```

But if we set appropriate specialization (or use `self.current_type`), get_resource return type is RemoteResource.

```python
from karton.core import Task, RemoteResource, Consumer

class SimpleConsumer(Consumer):
    identity = "karton.simple-consumer"

    def process(self, task: Task[RemoteResource]) -> None:
        sample = task.get_resource("ddd")
        sample.download() # correct, resolves to RemoteResource.download method type
```

Another nice feature is that we can't use incorrect RemoteResource type for specialization (e.g. using sync version instead of async in asyncio Consumer)

```python
import json

from karton.core.asyncio import Consumer, Task
# should be from karton.core.asyncio import RemoteResource
from karton.core import RemoteResource

class FooBarConsumer(Consumer):
    identity = "foobar-consumer"
    filters = [{"type": "foobar"}]
    concurrency_limit = 2

    async def process(self, task: Task[RemoteResource]) -> None:
        # error: Argument 1 of "process" is incompatible with supertype "Consumer"
        data = task.get_resource("data")
        num = json.loads(await data.download())["data"]
```