### PR TITLE
Fix: missing record.task_id for descendant loggers (e.g. karton.<identity>.module)

### DIFF
--- a/karton/core/base.py
+++ b/karton/core/base.py
@@ -131,11 +131,11 @@ class LoggingMixin:
         if not self.identity:
             raise ValueError("Can't setup logger without identity")
 
+        task_context_filter = TaskContextFilter()
         self._log_handler.setFormatter(logging.Formatter())
+        self._log_handler.addFilter(task_context_filter)
 
         logger = logging.getLogger(self.identity)
-        logger.addFilter(TaskContextFilter())
-
         if logger.handlers:
             # If logger already have handlers set: clear them
             logger.handlers.clear()
@@ -148,6 +148,7 @@ class LoggingMixin:
         logger.setLevel(log_level)
         stream_handler = logging.StreamHandler()
         stream_handler.setFormatter(logging.Formatter(self._log_format))
+        stream_handler.addFilter(task_context_filter)
         logger.addHandler(stream_handler)
 
         if not self.debug and self.enable_publish_log:


### PR DESCRIPTION
When we try to use a logger that is descendant to the `karton.<identity>` logger (e.g. `karton.identity.something`), we may get the following error:

```
--- Logging error ---
Traceback (most recent call last):
  File "/usr/lib/python3.12/logging/__init__.py", line 464, in format
    return self._format(record)
           ^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/logging/__init__.py", line 460, in _format
    return self._fmt % values
           ~~~~~~~~~~^~~~~~~~
KeyError: 'task_id'
```

That's because logging.Filter doesn't propagate and when it's attached to logger, it applies only to that logger.

If Formatter depends on context set by Filter, Filter should be applied to the Handler using that Formatter instead of Logger.