### PR TITLE
Unify KartonServiceInfo objects, add 'instance_id' field to deduplicate connections from the same replica

### DIFF
--- a/karton/core/backend/base.py
+++ b/karton/core/backend/base.py
@@ -1,5 +1,6 @@
 import dataclasses
 import enum
+import uuid
 from typing import IO, Any, Iterator, Protocol
 
 from karton.core.__version__ import __version__
@@ -38,9 +39,9 @@ class KartonServiceInfo:
     """
 
     identity: str
-    karton_version: str
+    karton_version: str | None = None
     service_version: str | None = None
-    secondary: bool = False
+    instance_id: str | None = None
 
 
 def resolve_service_info(
@@ -63,6 +64,7 @@ def resolve_service_info(
         service_info = KartonServiceInfo(
             identity=identity,
             karton_version=__version__,
+            instance_id=str(uuid.uuid4()),
         )
     disallowed_chars = [" ", "?"]
     if any(

--- a/karton/core/base.py
+++ b/karton/core/base.py
@@ -3,6 +3,7 @@ import argparse
 import logging
 import os
 import textwrap
+import uuid
 from contextlib import contextmanager
 from typing import Optional, Protocol, Union, cast
 
@@ -218,6 +219,7 @@ class KartonBase(abc.ABC, ConfigMixin, LoggingMixin):
             identity=self.identity,
             karton_version=__version__,
             service_version=self.version,
+            instance_id=str(uuid.uuid4()),
         )
 
         self.backend = backend or self._backend_factory(

--- a/karton/gateway/app.py
+++ b/karton/gateway/app.py
@@ -75,7 +75,7 @@ async def initiate_session(websocket: WebSocket) -> UserSession:
         identity=hello_request.message.identity,
         karton_version=hello_request.message.library_version,
         service_version=hello_request.message.service_version,
-        secondary=hello_request.message.secondary_connection,
+        instance_id=hello_request.message.instance_id,
     )
     user_session = UserSession(
         user=user,

--- a/karton/gateway/models.py
+++ b/karton/gateway/models.py
@@ -43,7 +43,7 @@ class HelloRequestMessage(BaseModel):
     identity: str
     service_version: str | None
     library_version: str
-    secondary_connection: bool
+    instance_id: str
     credentials: AuthCredentials | None = None
 
 

--- a/karton/gateway/operations.py
+++ b/karton/gateway/operations.py
@@ -64,12 +64,19 @@ class UserSession:
     def __init__(self, user: User, service_info: KartonServiceInfo):
         self.user = user
         self.service_info = service_info
+        if self.service_info.karton_version is None:
+            raise ValueError("Karton version in service_info cannot be None")
+        self._karton_version: str = self.service_info.karton_version
         self.karton_bind: KartonBind | None = None
         self.backend: KartonAsyncBackend | None = None
 
     @property
     def identity(self) -> str:
         return self.service_info.identity
+
+    @property
+    def karton_version(self) -> str:
+        return self._karton_version
 
     @property
     def username(self) -> str:
@@ -167,7 +174,7 @@ async def handle_bind_request(
     bind = KartonBind(
         identity=session.service_info.identity,
         info=request.message.info,
-        version=session.service_info.karton_version,
+        version=session.karton_version,
         persistent=request.message.persistent,
         filters=request.message.filters,
         service_version=session.service_info.service_version,


### PR DESCRIPTION
Karton uses `CLIENT NAME` to bind Karton service metadata with Redis connection. This information is used to count active replicas and to remove inactive non-persistent queues.

The problem is that in case of concurrent Redis calls, more than one connection may be used by the client. Initially I thought that this can be fixed by `single_connection_client` option that sets a lock in connection pool instead of spawning new connections. Unfortunately, asyncio Redis client still keeps two connections opened, making replicas count value completely unreliable.

This PR contains two changes:
- introduces `instance_id` in KartonServiceInfo object and generated during KartonBase construction (or in KartonBackend if someone uses it standalone). All connections coming from the same instance of service should have same `instance_id`
- `instance_id` can be passed as an argument to "hello" request in Karton Gateway, along with other KartonServiceInfo information.
- `KartonServiceInfo.karton_version` is optional to be able to parse all `CLIENT NAME` values to KartonServiceInfo, regardless of whether they have extended fields or not.

The replica counting logic should be as follows:

- `KartonServiceInfo.instance_id=<uuid>` : objects should be deduplicated by `instance_id` and each object should be counted as a separate replica of `identity`
- `KartonServiceInfo.instance_id=None` (coming from <6.0.0): each object should be counted as a separate replica of `identity`