### PR TITLE
Fix consume_log iterator, add docstring

### DIFF
--- a/karton/core/backend.py
+++ b/karton/core/backend.py
@@ -966,7 +966,10 @@ class KartonBackend(KartonBackendBase):
                     if "task" in body and isinstance(body["task"], str):
                         body["task"] = json.loads(body["task"])
                     yield body
-                yield None
+                else:
+                    # return control back to the caller in case a shutdown or some
+                    #  other action was requested and needs to be handled
+                    yield None
 
     def increment_metrics(
         self, metric: KartonMetrics, identity: str, pipe: Optional[Pipeline] = None

--- a/karton/core/backend.py
+++ b/karton/core/backend.py
@@ -968,7 +968,7 @@ class KartonBackend(KartonBackendBase):
                     yield body
                 else:
                     # return control back to the caller in case a shutdown or some
-                    #  other action was requested and needs to be handled
+                    # other action was requested and needs to be handled
                     yield None
 
     def increment_metrics(


### PR DESCRIPTION
We don't need to yield `None` every time a log is received. Also add a docstring that explain why we even do it in the first place.